### PR TITLE
Remove hardcoded core button styles

### DIFF
--- a/assets/shared/css/blocks/button.css
+++ b/assets/shared/css/blocks/button.css
@@ -1,27 +1,9 @@
-/**
- * Gutenberg core Button block styling.
- */
-
-.wp-block-button__link {
-
-	&:not(.has-background) {
+.wp-block-button {
+	&:not(.is-style-outline) .wp-block-button__link:not(.has-background) {
 		background-color: hsl(var(--theme-color-primary));
 	}
-}
 
-/* Local scoped variables */
-.wp-block-button__link {
-	margin-bottom: 0.75rem !important;
-}
-
-/* stylelint-disable no-descending-specificity */
-.is-style-underlined .wp-block-button__link {
-	@mixin c-button-block-underlined;
-
-	&:hover,
-	&:focus,
-	&:active {
-		@mixin c-button-block-underlined-hover;
+	&.is-style-outline .wp-block-button__link:not(.has-text-color) {
+		color: hsl(var(--theme-color-primary));
 	}
 }
-/* stylelint-enable */


### PR DESCRIPTION
Resolves #81 

### Editor:
<img width="399" alt="Screen Shot 2019-08-02 at 2 50 25 PM" src="https://user-images.githubusercontent.com/5321364/62392240-f089cb80-b534-11e9-9258-a8089bc72642.png">

### Frontend:
<img width="370" alt="Screen Shot 2019-08-02 at 2 54 04 PM" src="https://user-images.githubusercontent.com/5321364/62392447-6db54080-b535-11e9-92f7-a89e89937b73.png">

