### PR TITLE
Fix path to package.json from pa11y.js

### DIFF
--- a/.dev/tests/accessibility/compliance/pa11y.js
+++ b/.dev/tests/accessibility/compliance/pa11y.js
@@ -4,7 +4,7 @@
 
 const pa11y = require( 'pa11y' );
 const chalk = require( 'chalk' );
-const packageJson = require( '../../../package.json' );
+const packageJson = require( '../../../../package.json' );
 const testingUrls = packageJson.testing.urls;
 
 // Initialize variables
@@ -73,7 +73,7 @@ const config = {
  * @returns {object} test results
  */
 pa11y( url, config, ( error, results ) => {
-	
+
 	if( error ) {
 
 		return console.error( error );


### PR DESCRIPTION
Tried running the a11y tests and found that after https://github.com/godaddy/wp-project-maverick/pull/163 was merged the path to the `package.json` file was incorrect causing the tests not to run.

<img width="1030" alt="Screen Shot 2019-08-14 at 4 24 50 PM" src="https://user-images.githubusercontent.com/5321364/63053582-15286080-beb0-11e9-9e79-e156eb22ecb6.png">

