### PR TITLE
Remove overflow from site-header.

### DIFF
--- a/.dev/assets/shared/css/header/primary-menu.css
+++ b/.dev/assets/shared/css/header/primary-menu.css
@@ -79,6 +79,7 @@
 		list-style: none;
 		margin: 0;
 		padding: 0;
+		z-index: 999;
 
 		@media (--large) {
 			display: none;

--- a/.dev/assets/shared/css/header/site-header.css
+++ b/.dev/assets/shared/css/header/site-header.css
@@ -1,7 +1,6 @@
 /*! Header */
 .site-header {
 	background-color: hsla(var(--theme-header--bg), 1);
-	overflow: hidden;
 
 	& .u-informational {
 		display: inline-block;


### PR DESCRIPTION
Resolves #193 

The initial PR that added the overflow was #180. I planned on removing this and adding `overflow-x: hidden` to the `body` element but it looks to be already in-place, added by PR #115 (https://github.com/godaddy/wp-project-maverick/pull/115/files#diff-caad6b6ec92267565755de4b042ffc4fR27).

I can't seem to reproduce the side-scrolling issue in Safari anymore. Maybe the `tabindex="-1"` fix added in #118 resolved the issue.

@richtabor can you see if you're still having this side-scrolling issue?