### PR TITLE
Prevent empty title tags in home.php

### DIFF
--- a/home.php
+++ b/home.php
@@ -9,7 +9,7 @@ get_header(); ?>
 
 	<div class="content-area">
 
-		<h1 class="page-title"><?php single_post_title(); ?></h1>
+		<?php single_post_title( '<h1 class="page-title">', '</h1>' ); ?>
 
 		<?php if ( have_posts() ) : ?>
 			<?php while ( have_posts() ) : the_post(); ?>


### PR DESCRIPTION
Pass `$before`/`$after` parameters to `the_title()` in `home.php` to prevent empty title tags from displaying on the homepage when displaying the latest blog posts. This should get our current `a11y` tests passing.