### PR TITLE
Check if post has tags before using the_tags()

### DIFF
--- a/single.php
+++ b/single.php
@@ -31,14 +31,16 @@ get_header(); ?>
 						<h1 class="post__title"><?php the_title(); ?></h1>
 						<span class="post__author"><?php esc_html_e( 'by', 'maverick' ); ?> <?php the_author_posts_link(); ?></span>
 						<?php
-						the_tags(
-							sprintf(
-								'<span class="post__tags"><span class="screen-reader-text">%s</span> ',
-								esc_html_e( 'Tags:', 'maverick' )
-							),
-							', ',
-							'</span>'
-						);
+						if ( get_the_tag_list() ) {
+							the_tags(
+								sprintf(
+									'<span class="post__tags"><span class="screen-reader-text">%s</span> ',
+									esc_html_e( 'Tags:', 'maverick' )
+								),
+								', ',
+								'</span>'
+							);
+						}
 						?>
 					</div>
 				</div>


### PR DESCRIPTION
Check if the post has any tags before using `the_tags()`. Using 'Tags:' in the parameter of `the_tags()` causes this to be output even when no tags exist.