### PR TITLE
Tweak styles for WooCommerce > Account Details

### DIFF
--- a/.dev/assets/shared/css/shared-style.css
+++ b/.dev/assets/shared/css/shared-style.css
@@ -102,6 +102,7 @@
 
 /*! WooCommerce */
 @import url("woocommerce/layout.css");
+@import url("woocommerce/account.css");
 @import url("woocommerce/button.css");
 @import url("woocommerce/pagination.css");
 @import url("woocommerce/forms.css");

--- a/.dev/assets/shared/css/woocommerce/account.css
+++ b/.dev/assets/shared/css/woocommerce/account.css
@@ -1,0 +1,16 @@
+.woocommerce-account {
+
+	& .woocommerce-MyAccount-navigation ul {
+		list-style: none;
+		margin: 0;
+		padding-left: 0;
+
+		& li.woocommerce-MyAccount-navigation-link {
+			margin-left: 0;
+		}
+	}
+
+	& .woocommerce-MyAccount-content {
+		width: 70%;
+	}
+}

--- a/.dev/assets/shared/css/woocommerce/layout.css
+++ b/.dev/assets/shared/css/woocommerce/layout.css
@@ -18,13 +18,3 @@
 		margin-bottom: 2rem;
 	}
 }
-
-.woocommerce .woocommerce-MyAccount-navigation ul {
-	list-style: none;
-	margin: 0;
-	padding-left: 0;
-
-	& li.woocommerce-MyAccount-navigation-link {
-		margin-left: 0;
-	}
-}


### PR DESCRIPTION
Resolves #261 

- Add a border color to the text input fields (inherit `--theme-color-primary`).
- Slightly minimize the margin between input fields (`3.75rem` -> `2.5rem`).
- Remove `list-style` and left hand `margin` on Account navigation on the left hand side.