### PR TITLE
Tweak account addresses

### DIFF
--- a/.dev/assets/shared/css/shared-style.css
+++ b/.dev/assets/shared/css/shared-style.css
@@ -102,6 +102,7 @@
 
 /*! WooCommerce */
 @import url("woocommerce/layout.css");
+@import url("woocommerce/account.css");
 @import url("woocommerce/button.css");
 @import url("woocommerce/pagination.css");
 @import url("woocommerce/forms.css");

--- a/.dev/assets/shared/css/woocommerce/account.css
+++ b/.dev/assets/shared/css/woocommerce/account.css
@@ -1,0 +1,10 @@
+.woocommerce-account {
+
+	& .col2-set.addresses {
+
+		& .col-1,
+		& .col-2 {
+			width: 100%;
+		}
+	}
+}


### PR DESCRIPTION
Resolves #264 

Tweak column width of addresses due to page width.
- Sets the 2 column layout to single column which works better, visually.

### Note
The styles for the white space gaps and input borders is resolved in #269 