### PR TITLE
Fix Footer Heading Color control

### DIFF
--- a/.dev/assets/admin/js/customize-controls.js
+++ b/.dev/assets/admin/js/customize-controls.js
@@ -64,7 +64,7 @@ import './customize/controls/range-control';
 		}
 
 		// Only show the Footer Header Color selector, if the footer variation is 2 or 4.
-		customizerOptionDisplay( 'footer_variation', 'footer_heading_color', 'footer-2', 'footer-4', 100 );
+		customizerOptionDisplay( 'footer_variation', 'footer_heading_color', 'footer-3', 'footer-4', 100 );
 
 		// Only show the following options, if a logo is uploaded.
 		customizerImageOptionDisplay( 'custom_logo', 'logo_width', 100 );


### PR DESCRIPTION
This PR tweaks the show/hide functionality of the Footer Heading Color control, so that it display when Footer 3 and Footer 4 are enabled. 
![ScreenFlow](https://user-images.githubusercontent.com/1813435/63459298-44941b80-c422-11e9-8d5a-47b8e1fb5da0.gif)
