### PR TITLE
Remove "/" from instances of get_theme_file_uri()

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -261,7 +261,7 @@ function block_editor_assets() {
 
 	wp_enqueue_script(
 		'maverick-block-filters',
-		get_theme_file_uri( '/dist/js/admin/block-filters.js' ),
+		get_theme_file_uri( 'dist/js/admin/block-filters.js' ),
 		[ 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ],
 		MAVERICK_VERSION,
 		true
@@ -280,7 +280,7 @@ function scripts() {
 
 	wp_enqueue_script(
 		'maverick-frontend',
-		get_theme_file_uri( "/dist/js/frontend{$suffix}.js" ),
+		get_theme_file_uri( "dist/js/frontend{$suffix}.js" ),
 		[],
 		MAVERICK_VERSION,
 		true
@@ -335,7 +335,7 @@ function styles() {
 
 	wp_enqueue_style(
 		'maverick-style',
-		get_theme_file_uri( "/dist/css/style-shared{$suffix}.css" ),
+		get_theme_file_uri( "dist/css/style-shared{$suffix}.css" ),
 		[ 'maverick-fonts' ],
 		MAVERICK_VERSION
 	);
@@ -502,7 +502,7 @@ function get_available_design_styles() {
 	$default_design_styles = [
 		'modern'      => [
 			'label'         => esc_html__( 'Modern', 'maverick' ),
-			'url'           => get_theme_file_uri( "/dist/css/design-styles/style-modern{$suffix}.css" ),
+			'url'           => get_theme_file_uri( "dist/css/design-styles/style-modern{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-modern-editor{$suffix}.css",
 			'color_schemes' => [
 				'one'   => [
@@ -552,7 +552,7 @@ function get_available_design_styles() {
 		],
 		'traditional' => [
 			'label'         => esc_html__( 'Traditional', 'maverick' ),
-			'url'           => get_theme_file_uri( "/dist/css/design-styles/style-traditional{$suffix}.css" ),
+			'url'           => get_theme_file_uri( "dist/css/design-styles/style-traditional{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-traditional-editor{$suffix}.css",
 			'color_schemes' => [
 				'one'   => [
@@ -601,7 +601,7 @@ function get_available_design_styles() {
 		],
 		'trendy'      => [
 			'label'         => esc_html__( 'Trendy', 'maverick' ),
-			'url'           => get_theme_file_uri( "/dist/css/design-styles/style-trendy{$suffix}.css" ),
+			'url'           => get_theme_file_uri( "dist/css/design-styles/style-trendy{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-trendy-editor{$suffix}.css",
 			'color_schemes' => [
 				'one' => [
@@ -622,7 +622,7 @@ function get_available_design_styles() {
 		],
 		'welcoming'   => [
 			'label'         => esc_html__( 'Welcoming', 'maverick' ),
-			'url'           => get_theme_file_uri( "/dist/css/design-styles/style-welcoming{$suffix}.css" ),
+			'url'           => get_theme_file_uri( "dist/css/design-styles/style-welcoming{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-welcoming-editor{$suffix}.css",
 			'color_schemes' => [
 				'one' => [
@@ -643,7 +643,7 @@ function get_available_design_styles() {
 		],
 		'playful'     => [
 			'label'         => esc_html__( 'Playful', 'maverick' ),
-			'url'           => get_theme_file_uri( "/dist/css/design-styles/style-playful{$suffix}.css" ),
+			'url'           => get_theme_file_uri( "dist/css/design-styles/style-playful{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-playful-editor{$suffix}.css",
 			'color_schemes' => [
 				'one' => [
@@ -717,35 +717,35 @@ function get_available_header_variations() {
 	$default_header_variations = [
 		'header-1' => [
 			'label'         => esc_html__( 'Header 1', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/header-1.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-1.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '1' );
 			},
 		],
 		'header-2' => [
 			'label'         => esc_html__( 'Header 2', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/header-2.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-2.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '2' );
 			},
 		],
 		'header-3' => [
 			'label'         => esc_html__( 'Header 3', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/header-3.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-3.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '3' );
 			},
 		],
 		'header-4' => [
 			'label'         => esc_html__( 'Header 4', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/header-4.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-4.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '4' );
 			},
 		],
 		'header-5' => [
 			'label'         => esc_html__( 'Header 5', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/header-5.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-5.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '5' );
 			},
@@ -791,28 +791,28 @@ function get_available_footer_variations() {
 	$default_footer_variations = [
 		'footer-1' => [
 			'label'         => esc_html__( 'Footer 1', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/footer-1.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-1.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '1' );
 			},
 		],
 		'footer-2' => [
 			'label'         => esc_html__( 'Footer 2', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/footer-2.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-2.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '2' );
 			},
 		],
 		'footer-3' => [
 			'label'         => esc_html__( 'Footer 3', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/footer-3.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-3.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '3' );
 			},
 		],
 		'footer-4' => [
 			'label'         => esc_html__( 'Footer 4', 'maverick' ),
-			'preview_image' => get_theme_file_uri( '/dist/images/admin/footer-4.svg' ),
+			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-4.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '4' );
 			},

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -159,7 +159,7 @@ function customize_preview_init() {
 
 	wp_enqueue_script(
 		'maverick-customize-preview',
-		get_theme_file_uri( "/dist/js/admin/customize-preview{$suffix}.js" ),
+		get_theme_file_uri( "dist/js/admin/customize-preview{$suffix}.js" ),
 		[ 'jquery', 'customize-preview', 'wp-autop' ],
 		MAVERICK_VERSION,
 		true
@@ -185,7 +185,7 @@ function enqueue_controls_assets() {
 
 	wp_enqueue_script(
 		'maverick-customize-controls',
-		get_theme_file_uri( "/dist/js/admin/customize-controls{$suffix}.js" ),
+		get_theme_file_uri( "dist/js/admin/customize-controls{$suffix}.js" ),
 		[ 'jquery' ],
 		MAVERICK_VERSION,
 		true
@@ -193,7 +193,7 @@ function enqueue_controls_assets() {
 
 	wp_enqueue_style(
 		'maverick-customize-style',
-		get_theme_file_uri( "/dist/css/admin/style-customize{$suffix}.css" ),
+		get_theme_file_uri( "dist/css/admin/style-customize{$suffix}.css" ),
 		[],
 		MAVERICK_VERSION
 	);


### PR DESCRIPTION
This PR removes the `/` from get_theme_file_uri() as the function actually removes the `/` via `ltrim()` ([source](https://developer.wordpress.org/reference/functions/get_theme_file_uri/#source)). 