### PR TITLE
Tweak accordion style

### DIFF
--- a/.dev/assets/design-styles/modern/settings.css
+++ b/.dev/assets/design-styles/modern/settings.css
@@ -380,7 +380,8 @@
 	--coblocks-accordion--bg: var(--color-white);
 	--coblocks-accordion--bg-hover: hsla(var(--theme-selection--color), 0.1);
 	--coblocks-accordion--border-color: var(--theme-color-heading);
-	--coblocks-accordion--border: 2px solid hsl(var(--coblocks-accordion--border-color));
+	--coblocks-accordion--border-width: 2px;
+	--coblocks-accordion--border: var(--coblocks-accordion--border-width) solid hsl(var(--coblocks-accordion--border-color));
 	--coblocks-accordion--color: var(--theme-color-heading);
 	--coblocks-accordion--radius: 0;
 

--- a/.dev/assets/design-styles/traditional/settings.css
+++ b/.dev/assets/design-styles/traditional/settings.css
@@ -38,7 +38,7 @@
 
 	@media (--large) {
 		--theme-block-spacing: 1.8rem;
-		--theme-block-spacing-larger: 2rem;
+		--theme-block-spacing-larger: 2.25rem;
 		--theme-block-spacing-huge: 8rem;
 	}
 
@@ -382,12 +382,13 @@
 	/*--------------------------------------------------------------
 	## CoBlocks
 	--------------------------------------------------------------*/
-	--coblocks-accordion--bg: var(--color-white);
-	--coblocks-accordion--bg-hover: hsla(var(--theme-selection--color), 0.1);
+	--coblocks-accordion--bg: var(--theme-color-tertiary);
+	--coblocks-accordion--bg-hover: none;
 	--coblocks-accordion--border-color: var(--theme-color-heading);
-	--coblocks-accordion--border: 2px solid hsl(var(--coblocks-accordion--border-color));
+	--coblocks-accordion--border-width: 2px;
+	--coblocks-accordion--border: var(--coblocks-accordion--border-width) solid hsl(var(--coblocks-accordion--border-color));
 	--coblocks-accordion--color: var(--theme-color-heading);
-	--coblocks-accordion--radius: 0;
+	--coblocks-accordion--radius: 3px;
 
 	--coblocks-author--bg: var(--theme-color-tertiary);
 	--coblocks-author--color-heading: var(--theme-color-text-secondary);

--- a/.dev/assets/shared/css/coblocks/accordion.css
+++ b/.dev/assets/shared/css/coblocks/accordion.css
@@ -5,6 +5,8 @@
 }
 
 .wp-block-coblocks-accordion-item__title {
+	border: var(--coblocks-accordion--border);
+	border-radius: var(--coblocks-accordion--radius);
 
 	&:not(.has-background) {
 		background: hsl(var(--coblocks-accordion--bg));
@@ -16,7 +18,7 @@
 
 	&:hover::after {
 		background: var(--coblocks-accordion--bg-hover);
-		border-radius: var(--coblocks-accordion--radius);
+		border-radius: var(--coblocks-accordion--radius) var(--coblocks-accordion--radius) 0 0;
 	}
 
 	&:focus {
@@ -25,16 +27,12 @@
 	}
 }
 
-.wp-block-coblocks-accordion-item__title,
 .wp-block-coblocks-accordion-item__content {
 	border: var(--coblocks-accordion--border);
-	border-radius: var(--coblocks-accordion--radius);
-}
-
-.wp-block-coblocks-accordion-item__content {
 	border-color: hsl(var(--coblocks-accordion--border-color)) !important;
+	margin-top: calc(var(--coblocks-accordion--border-width) * -1);
 }
 
 .wp-block-coblocks-accordion-item details[open] summary {
-	border-radius: var(--coblocks-accordion--radius);
+	border-radius: var(--coblocks-accordion--radius) var(--coblocks-accordion--radius) 0 0;
 }

--- a/.dev/assets/shared/css/layout/content.css
+++ b/.dev/assets/shared/css/layout/content.css
@@ -8,7 +8,7 @@
 	padding-left: var(--theme-block-padding-x);
 	padding-right: var(--theme-block-padding-x);
 
-	&:not(p):not(ul):not(ol):not(.wp-block-spacer):not(.wp-block-image):not(.wp-block-file):not(.wp-block-preformatted):not(.wp-block-verse):not(.wp-block-categories-dropdown):not(.wp-block-archives-dropdown):not(.wp-block-code):not(.wp-block-coblocks-alert) {
+	&:not(p):not(ul):not(ol):not(.wp-block-spacer):not(.wp-block-image):not(.wp-block-file):not(.wp-block-preformatted):not(.wp-block-verse):not(.wp-block-categories-dropdown):not(.wp-block-archives-dropdown):not(.wp-block-code):not(.wp-block-coblocks-alert):not(.wp-block-coblocks-accordion) {
 		margin-bottom: var(--theme-block-spacing-huge);
 		margin-top: var(--theme-block-spacing-huge);
 	}
@@ -50,7 +50,8 @@
 
 		& figure,
 		& blockquote,
-		& .wp-block-cover {
+		& .wp-block-cover,
+		& .wp-block-coblocks-accordion {
 
 			/* Remove huge spacing when right after a paragraph */
 			margin-bottom: var(--theme-block-spacing-larger) !important;


### PR DESCRIPTION
This PR applies a few minor fixes to the CoBlocks Accordion block, as well as fixes how the accordions display within paragraph blocks (same padding as paragraph blocks)

Modern Accordion: 
<img width="726" alt="Screen Shot 2019-08-23 at 10 17 05 AM" src="https://user-images.githubusercontent.com/1813435/63599526-cc4b6880-c58f-11e9-93ee-258263990e56.png">

Traditional Accordion:
<img width="773" alt="Screen Shot 2019-08-23 at 10 21 52 AM" src="https://user-images.githubusercontent.com/1813435/63599545-d5d4d080-c58f-11e9-8bd2-f570d19fa5a6.png">