### PR TITLE
Hide footer nav #2 and #3 when footer variation is #3 or #4.

### DIFF
--- a/.dev/assets/admin/js/customize-controls.js
+++ b/.dev/assets/admin/js/customize-controls.js
@@ -15,6 +15,11 @@ import './customize/controls/range-control';
 		 * Function to hide/show Customizer options, based on another control.
 		 *
 		 * Parent option, Affected Control, Value which affects the control.
+		 *
+		 * @param {String} parentSetting The setting that will toggle the display of the control.
+		 * @param {String} affectedControl The control that will be toggled.
+		 * @param {Array} values The values the parentSetting must have for the affectedControl to be displayed.
+		 * @param {Integer} speed The speed of the toggle animation.
 		 */
 		function customizerOptionDisplay( parentSetting, affectedControl, values, speed = 100 ) {
 			wp.customize( parentSetting, function( setting ) {
@@ -40,6 +45,10 @@ import './customize/controls/range-control';
 		 * Function to hide/show Customizer options, based on another control.
 		 *
 		 * Parent option, Affected Control, Value which affects the control.
+		 *
+		 * @param {String} parentSetting The setting that will toggle the display of the control.
+		 * @param {String} affectedControl The control that will be toggled.
+		 * @param {Integer} speed The speed of the toggle animation.
 		 */
 		function customizerImageOptionDisplay( parentSetting, affectedControl, speed = 100 ) {
 			wp.customize( parentSetting, function( setting ) {


### PR DESCRIPTION
Resolves #242 

This PR ensures the footer navigation 2 and 3 locations are hidden in the customizer when footer variation 1 or 2 is selected. This change needs to be made because footer variations 1 and 2 do not support the footer nav 2 and3 locations.

**Footer Variation 1 active**

![footer-variation-1](https://user-images.githubusercontent.com/375788/64206519-88e2db00-ce68-11e9-8b65-651cceb48276.png)

**Footer Variation 3 active**

![footer-variation-3](https://user-images.githubusercontent.com/375788/64206549-9ef09b80-ce68-11e9-87e2-5b985bfa1ede.png)
