### PR TITLE
Fix menu line height

### DIFF
--- a/.dev/assets/design-styles/modern/css/style-modern.css
+++ b/.dev/assets/design-styles/modern/css/style-modern.css
@@ -55,7 +55,7 @@ p.has-background,
 
 	&::after {
 		background-color: currentColor;
-		bottom: -5px;
+		bottom: 0;
 		content: "";
 		height: 2px;
 		left: 0;

--- a/.dev/assets/shared/css/header/site-branding.css
+++ b/.dev/assets/shared/css/header/site-branding.css
@@ -1,6 +1,6 @@
 /*! Header: Site Branding */
 .site-branding {
-	flex: 1 0 50%;
+	flex: 1 0 33%;
 	line-height: 1.1;
 	max-width: 50%;
 	position: relative;

--- a/.dev/assets/shared/css/header/site-navigation.css
+++ b/.dev/assets/shared/css/header/site-navigation.css
@@ -5,7 +5,6 @@
 	flex-direction: column;
 	height: 0;
 	left: 0;
-	line-height: 1.2;
 	opacity: 0;
 	overflow-y: scroll;
 	position: fixed;


### PR DESCRIPTION
This PR provides a fix for when a lot of menu items are added to the primary menu and show up too close. There's no change in viewport width between the following screenshots. 

Before: 
<img width="1267" alt="Screen Shot 2019-09-03 at 5 01 32 PM" src="https://user-images.githubusercontent.com/1813435/64208276-7d91ae80-ce6c-11e9-85bb-2595649873aa.png">

After: 
<img width="1287" alt="Screen Shot 2019-09-03 at 5 00 21 PM" src="https://user-images.githubusercontent.com/1813435/64208203-5509b480-ce6c-11e9-8ea9-5dc49fa92d9b.png">
