### PR TITLE
Add check for post/page to has-featured-image

### DIFF
--- a/.dev/assets/shared/css/header/site-header.css
+++ b/.dev/assets/shared/css/header/site-header.css
@@ -12,10 +12,10 @@
 	padding: var(--theme-header--padding-y) var(--theme-block-padding-x);
 }
 
-.has-header-1.has-featured-image:not(.woocommerce-page),
-.has-header-2.has-featured-image:not(.woocommerce-page),
-.has-header-3.has-featured-image:not(.woocommerce-page),
-.has-header-4.has-featured-image:not(.woocommerce-page) {
+.has-header-1.has-featured-image,
+.has-header-2.has-featured-image,
+.has-header-3.has-featured-image,
+.has-header-4.has-featured-image {
 
 	& .site-header {
 		position: absolute;
@@ -70,7 +70,7 @@
 	}
 }
 
-.has-featured-image:not(.woocommerce-page) {
+.has-featured-image {
 
 	& .site-branding__title,
 	& .site-header .primary-menu a {

--- a/.dev/assets/shared/css/layout/content.css
+++ b/.dev/assets/shared/css/layout/content.css
@@ -50,8 +50,8 @@
 }
 
 /* Account for the first block if we have a featured image. */
-.has-featured-image:not(.woocommerce-page) .content-area > *:first-child {
-	margin-top: calc(var(--theme-block-spacing-huge) * 1) !important;
+.has-featured-image .content-area > *:first-child {
+	margin-top: var(--vertical-rhythm--lrg) !important;
 }
 
 /* Account for the first block being .alignfull */

--- a/.dev/assets/shared/css/layout/entry-header.css
+++ b/.dev/assets/shared/css/layout/entry-header.css
@@ -4,11 +4,11 @@
 	text-align: center;
 }
 
-.has-featured-image:not(.woocommerce-page) .entry-header {
+.has-featured-image .entry-header {
 	padding-top: var(--theme-entryheader--padding-top);
 }
 
-.has-header-3:not(.has-featured-image) .entry-header {
+.has-header-3 .entry-header {
 	@media (--large) {
 		padding-top: 0;
 	}

--- a/includes/core.php
+++ b/includes/core.php
@@ -513,7 +513,7 @@ function body_classes( $classes ) {
 		$classes[] = 'has-page-titles';
 	}
 
-	if ( has_post_thumbnail() ) {
+	if ( has_post_thumbnail() && ( is_singular( 'post' ) || is_single( 'page' ) ) ) {
 		$classes[] = 'has-featured-image';
 	}
 


### PR DESCRIPTION
This PR changed the body_classes, so that `.has-featured-image` is only added on post and page post types, therefore removing the need to add `:not(.woocommerce-page)` specificity throughout. That specificity was causing errors with how blocks display as it was more specific than the vertical spacing logic throughout. 