### PR TITLE
Tweak media player scrub bar and volume background colors

### DIFF
--- a/.dev/assets/shared/css/elements/media.css
+++ b/.dev/assets/shared/css/elements/media.css
@@ -13,3 +13,12 @@ img {
 	margin-left: auto;
 	margin-right: auto;
 }
+
+.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-total {
+	background: hsl(var(--color-white)) !important;
+}
+
+.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-current,
+.mejs-controls .mejs-time-rail .mejs-time-current {
+	background: hsl(var(--theme-color-primary)) !important;
+}

--- a/.dev/assets/shared/css/elements/media.css
+++ b/.dev/assets/shared/css/elements/media.css
@@ -15,7 +15,7 @@ img {
 }
 
 .mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-total {
-	background: hsl(var(--color-white)) !important;
+	background: hsl(var(--color-white)) !important; 
 }
 
 .mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-current,

--- a/.dev/assets/shared/css/elements/media.css
+++ b/.dev/assets/shared/css/elements/media.css
@@ -15,7 +15,7 @@ img {
 }
 
 .mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-total {
-	background: hsl(var(--color-white)) !important; 
+	background: hsl(var(--color-white)) !important;
 }
 
 .mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-current,


### PR DESCRIPTION
Resolves #367 

Sets the current play time and current volume to use the theme primary color as it's background color.

![image](https://user-images.githubusercontent.com/5321364/65172012-341f9280-da1a-11e9-9415-9651b4b1df5e.png)