### PR TITLE
Fix theme URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Go is an innovative, Gutenberg-first WordPress theme, hyper-focused on empowering makers to build beautifully rich websites with WordPress.
 
-[![CircleCI](https://circleci.com/gh/godaddy/wp-go-theme.svg?style=svg)](https://circleci.com/gh/godaddy/wp-go-theme) [![License](https://img.shields.io/badge/license-GPL--2.0-brightgreen.svg)](https://github.com/godaddy/wp-go-theme/blob/master/license.txt) [![PHP >= 5.6](https://img.shields.io/badge/php-%3E=%205.6-8892bf.svg)](https://secure.php.net/supported-versions.php) [![WordPress >= 5.0](https://img.shields.io/badge/wordpress-%3E=%205.0-blue.svg)](https://wordpress.org/download/release-archive/)
+[![CircleCI](https://circleci.com/gh/godaddy/wp-go-theme.svg?style=svg)](https://circleci.com/gh/godaddy/wp-go-theme) [![License](https://img.shields.io/badge/license-GPL--2.0-brightgreen.svg)](https://github.com/godaddy-wordpress/go/blob/master/license.txt) [![PHP >= 5.6](https://img.shields.io/badge/php-%3E=%205.6-8892bf.svg)](https://secure.php.net/supported-versions.php) [![WordPress >= 5.0](https://img.shields.io/badge/wordpress-%3E=%205.0-blue.svg)](https://wordpress.org/download/release-archive/)
 
 ## Description ##
 
@@ -28,7 +28,7 @@ Go is an innovative, Gutenberg-first WordPress theme, hyper-focused on empowerin
 
 **Contributing**
 
-You can fork and contribute back to Go by visiting [our public repo on GitHub](https://github.com/godaddy/wp-go-theme).
+You can fork and contribute back to Go by visiting [our public repo on GitHub](https://github.com/godaddy-wordpress/go).
 
 ## Installation ##
 

--- a/languages/go.pot
+++ b/languages/go.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Go 0.2.0\n"
-"Report-Msgid-Bugs-To: https://github.com/godaddy/wp-go-theme\n"
+"Report-Msgid-Bugs-To: https://github.com/godaddy-wordpress/go\n"
 "POT-Creation-Date: 2019-09-17 18:03:46+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -737,7 +737,7 @@ msgid "Go"
 msgstr ""
 
 #. Theme URI of the plugin/theme
-msgid "https://github.com/godaddy/wp-go-theme"
+msgid "https://github.com/godaddy-wordpress/go"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "go",
   "version": "0.2.0",
   "description": "Go is an innovative, Gutenberg-first WordPress theme, hyper-focused on empowering makers to build beautifully rich websites with WordPress.",
-  "homepage": "https://github.com/godaddy/wp-go-theme",
+  "homepage": "https://github.com/godaddy-wordpress/go",
   "repository": {
     "type": "git",
-    "url": "https://github.com/godaddy/wp-go-theme",
+    "url": "https://github.com/godaddy-wordpress/go",
     "base": "godaddy/wp-go-theme"
   },
   "author": {

--- a/readme.txt
+++ b/readme.txt
@@ -26,7 +26,7 @@ Go is an innovative, Gutenberg-first WordPress theme, hyper-focused on empowerin
 
 **Contributing**
 
-You can fork and contribute back to Go by visiting [our public repo on GitHub](https://github.com/godaddy/wp-go-theme).
+You can fork and contribute back to Go by visiting [our public repo on GitHub](https://github.com/godaddy-wordpress/go).
 
 == Installation ==
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /* stylelint-disable */
 /**
  * Theme Name:  Go
- * Theme URI:   https://github.com/godaddy/wp-go-theme
+ * Theme URI:   https://github.com/godaddy-wordpress/go
  * Description: Go is an innovative, Gutenberg-first WordPress theme, hyper-focused on empowering makers to build beautifully rich websites with WordPress.
  * Author:      GoDaddy
  * Author URI:  https://www.godaddy.com


### PR DESCRIPTION
This PR changes the theme URL from `https://github.com/godaddy/wp-go-theme` to `https://github.com/godaddy-wordpress/go`. 