### PR TITLE
Fix WooCommerce shop page title conditional visbility

### DIFF
--- a/.dev/assets/admin/js/customize/preview/page-titles.js
+++ b/.dev/assets/admin/js/customize/preview/page-titles.js
@@ -1,7 +1,7 @@
 export default () => {
 
 	wp.customize( 'page_titles', ( value ) => {
-		const selectors = '#content > .entry-header, body.page article .entry-header';
+		const selectors = '#content > .entry-header, body.page article .entry-header, body.woocommerce .entry-header';
 		value.bind( ( to ) => {
 			if ( to ) {
 				$( 'body' ).addClass( 'has-page-titles' );

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -516,7 +516,7 @@ function page_title() {
 
 	$show_titles = get_theme_mod( 'page_titles', true );
 
-	if ( ! $show_titles && function_exists( 'is_shop' ) && is_shop() ) {
+	if ( ! $show_titles && function_exists( 'is_shop' ) && is_shop() && ! is_customize_preview() ) {
 
 		return;
 

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -516,14 +516,10 @@ function page_title() {
 
 	$show_titles = get_theme_mod( 'page_titles', true );
 
-	if ( ! $show_titles && function_exists( 'is_shop' ) && is_shop() && ! is_customize_preview() ) {
-
-		return;
-
-	}
-
 	if (
-		! is_customize_preview() && ( is_front_page() || ( ! $show_titles && ! is_404() && ! is_search() && ! is_archive() ) )
+		! is_customize_preview() && ( is_front_page() ||
+		( ! $show_titles && ! is_404() && ! is_search() && ! is_archive() ) ||
+		( ! $show_titles && ( function_exists( 'is_shop' ) && is_shop() ) ) ) // WooCommerce shop.
 	) {
 
 		return;

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -514,8 +514,16 @@ function copyright( $args = [] ) {
  */
 function page_title() {
 
+	$show_titles = get_theme_mod( 'page_titles', true );
+
+	if ( ! $show_titles && function_exists( 'is_shop' ) && is_shop() ) {
+
+		return;
+
+	}
+
 	if (
-		! is_customize_preview() && ( is_front_page() || ( ! get_theme_mod( 'page_titles', true ) && ! is_404() && ! is_search() && ! is_archive() ) )
+		! is_customize_preview() && ( is_front_page() || ( ! $show_titles && ! is_404() && ! is_search() && ! is_archive() ) )
 	) {
 
 		return;
@@ -588,7 +596,7 @@ function page_title() {
 
 	printf(
 		'<header class="page-header entry-header m-auto px %1$s">%2$s</header>',
-		is_customize_preview() ? ( get_theme_mod( 'page_titles', true ) ? '' : ' display-none' ) : '',
+		is_customize_preview() ? ( get_theme_mod( 'page_titles', true ) ? '' : 'display-none' ) : '',
 		wp_kses(
 			$html,
 			[

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -30,9 +30,9 @@ function setup() {
 
 	add_action( 'woocommerce_cart_is_empty', $n( 'empty_cart_message' ), 10 );
 
-	add_filter( 'woocommerce_show_page_title', $n( 'shop_page_title_visibility' ) );
+	add_filter( 'woocommerce_show_page_title', $n( 'page_title_visibility' ) );
 
-	add_action( 'woocommerce_archive_description', $n( 'woocommerce_shop_title' ) );
+	add_action( 'woocommerce_archive_description', $n( 'shop_title' ) );
 
 }
 
@@ -85,11 +85,11 @@ function empty_cart_message() {
 /**
  * Toggle the visibility of WooCommerce shop page titles
  *
- * @param  bool $show_title Whether or not to display the shop title.
+ * @param  bool $show_title Whether or not to display the WooCommerce page title.
  *
- * @return bool             True when shop page and page_titles theme mod is enabled, else false.
+ * @return bool False when shop page, else true.
  */
-function shop_page_title_visibility( $show_title ) {
+function page_title_visibility( $show_title ) {
 
 	return is_shop() ? false : $show_title;
 
@@ -100,7 +100,7 @@ function shop_page_title_visibility( $show_title ) {
  *
  * @return mixed Markup for the shop page title
  */
-function woocommerce_shop_title() {
+function shop_title() {
 
 	if ( ! is_shop() ) {
 

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -91,7 +91,7 @@ function empty_cart_message() {
  */
 function shop_page_title_visibility( $show_title ) {
 
-	return ! is_shop();
+	return is_shop() ? false : $show_title;
 
 }
 
@@ -119,7 +119,7 @@ function woocommerce_shop_title() {
 /**
  * Filter the WooCommerce shop page title attributes
  *
- * @param  array $atts Title attributes.
+ * @param array $atts Title attributes.
  *
  * @return array Title attributes array
  */

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -30,6 +30,10 @@ function setup() {
 
 	add_action( 'woocommerce_cart_is_empty', $n( 'empty_cart_message' ), 10 );
 
+	add_filter( 'woocommerce_show_page_title', $n( 'shop_page_title_visibility' ) );
+
+	add_action( 'woocommerce_archive_description', $n( 'woocommerce_shop_title' ) );
+
 }
 
 /**
@@ -75,5 +79,55 @@ function empty_cart_message() {
 		),
 		esc_html( apply_filters( 'wc_empty_cart_message', __( 'Your cart is currently empty.', 'go' ) ) )
 	);
+
+}
+
+/**
+ * Toggle the visibility of WooCommerce shop page titles
+ *
+ * @param  bool $show_title Whether or not to display the shop title.
+ *
+ * @return bool             True when shop page and page_titles theme mod is enabled, else false.
+ */
+function shop_page_title_visibility( $show_title ) {
+
+	return ! is_shop();
+
+}
+
+/**
+ * Output a custom WooCommerce shop page title
+ *
+ * @return mixed Markup for the shop page title
+ */
+function woocommerce_shop_title() {
+
+	if ( ! is_shop() ) {
+
+		return;
+
+	}
+
+	add_filter( 'go_page_title_args', __NAMESPACE__ . '\\shop_title_attributes' );
+
+	\Go\page_title();
+
+	remove_filter( 'go_page_title_args', __NAMESPACE__ . '\\shop_title_attributes' );
+
+}
+
+/**
+ * Filter the WooCommerce shop page title attributes
+ *
+ * @param  array $atts Title attributes.
+ *
+ * @return array Title attributes array
+ */
+function shop_title_attributes( $atts ) {
+
+	$atts['title']         = woocommerce_page_title( false );
+	$atts['atts']['class'] = 'page__title m-0 text-center';
+
+	return $atts;
 
 }


### PR DESCRIPTION
Resolves #381 

Fixes conditionally showing page titles (based on `page_titles` theme mod setting) on the shop page and in the customizer.