### PR TITLE
Fix archive page title output

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -1203,7 +1203,11 @@ function filter_page_titles( $args ) {
 
 	if ( is_archive() ) {
 
-		$args['title'] = get_the_archive_title();
+		$args['custom'] = true;
+		$args['title']  = sprintf(
+			'<h1 class="post__title m-0 text-center">%s</h1>',
+			get_the_archive_title()
+		);
 
 	}
 


### PR DESCRIPTION
Fixes the output of the page title on the archive templates.

### Before
![image](https://user-images.githubusercontent.com/5321364/67106762-39970680-f199-11e9-9e01-f205d708283d.png)

### After
![image](https://user-images.githubusercontent.com/5321364/67106694-1cface80-f199-11e9-8f50-4349d13eca89.png)
