### PR TITLE
Fix empty cart message icon

### DIFF
--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -55,6 +55,10 @@ function setup() {
  */
 function empty_cart_message() {
 
+	ob_start();
+	load_inline_svg( 'empty-cart.svg' );
+	$icon = ob_get_clean();
+
 	printf(
 		'<div class="max-w-base m-0 px m-auto text-center">
 			<div class="cart-empty-icon">
@@ -66,7 +70,7 @@ function empty_cart_message() {
 		</div>',
 		esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ),
 		wp_kses(
-			load_inline_svg( 'empty-cart.svg' ),
+			$icon,
 			array_merge(
 				wp_kses_allowed_html( 'post' ),
 				[


### PR DESCRIPTION
I believe this was introduced when we altered the functionality of `load_inline_svg` to `echo` the icon instead of `return` it.

#### Before
![image](https://user-images.githubusercontent.com/5321364/67300364-d7514500-f4bb-11e9-8360-e362a0dded63.png)

#### After
![image](https://user-images.githubusercontent.com/5321364/67300402-e506ca80-f4bb-11e9-8c19-03d3f003de45.png)

