### PR TITLE
Fix Playful design style header text color

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -780,7 +780,7 @@ function get_available_design_styles() {
 					'tertiary'          => '#f7fbff',
 					'background'        => '#ffffff',
 					'header_background' => '#3f46ae',
-					'header_text_color' => '#fafafa',
+					'header_text'       => '#fafafa',
 					'footer_background' => '#3f46ae',
 				],
 				'two'   => [

--- a/includes/core.php
+++ b/includes/core.php
@@ -790,6 +790,7 @@ function get_available_design_styles() {
 					'tertiary'          => '#fff7f7',
 					'background'        => '#ffffff',
 					'header_background' => '#eb616a',
+					'header_text'       => '#fafafa',
 					'footer_background' => '#eb616a',
 				],
 				'three' => [
@@ -799,6 +800,7 @@ function get_available_design_styles() {
 					'tertiary'          => '#f2f9f7',
 					'background'        => '#ffffff',
 					'header_background' => '#3c896d',
+					'header_text'       => '#fafafa',
 					'footer_background' => '#3c896d',
 				],
 				'four'  => [
@@ -808,6 +810,7 @@ function get_available_design_styles() {
 					'tertiary'          => '#f7feff',
 					'background'        => '#ffffff',
 					'header_background' => '#117495',
+					'header_text'       => '#fafafa',
 					'footer_background' => '#117495',
 				],
 			],


### PR DESCRIPTION
Fixes regression introduced in https://github.com/godaddy-wordpress/go/pull/396/commits/098f8d7c15f9e77a1d14a515aa2204c6856b5df4

This is because the `_color` in `header_text_color` gets replaced in our `color-schemes.js` controller. 
https://github.com/godaddy-wordpress/go/blob/9d4155e4d87fd4032a6cd85e4bdaf96199833d87/.dev/assets/admin/js/customize/preview/color-schemes.js#L33

The value then becomes `header_text` and must match the value defined in our `$default_design_styles` array.
https://github.com/godaddy-wordpress/go/blob/9d4155e4d87fd4032a6cd85e4bdaf96199833d87/includes/core.php#L783