### PR TITLE
Re-add the search form to the header

### DIFF
--- a/.dev/assets/shared/css/header/header.css
+++ b/.dev/assets/shared/css/header/header.css
@@ -30,7 +30,7 @@
 	justify-content: flex-start;
 	margin-left: -0.75rem;
 	order: 1;
-	z-index: 9999;
+	z-index: 10000;
 
 	@media (--large) {
 		flex: inherit;

--- a/.dev/assets/shared/css/header/site-search.css
+++ b/.dev/assets/shared/css/header/site-search.css
@@ -2,14 +2,15 @@
 .header {
 
 	& .site-search {
-		z-index: 2;
+		left: unset;
+		max-width: 25%;
+		right: unset;
+		width: 100%;
 
 		@media (--large) {
-			left: 0;
 			opacity: 0;
 			pointer-events: none;
 			position: absolute;
-			right: -0.75rem;
 			transform: translateX(60%);
 			transition: opacity 175ms ease-out 75ms, transform ease-out 175ms;
 		}
@@ -74,7 +75,7 @@
 			opacity: 1;
 			pointer-events: all;
 			transform: translateX(0);
-			z-index: 9999;
+			z-index: 10000;
 		}
 	}
 }

--- a/.dev/assets/shared/js/frontend/components/search-toggle.js
+++ b/.dev/assets/shared/js/frontend/components/search-toggle.js
@@ -120,7 +120,9 @@ const toggleSearch = ( searchForm, searchToggle, focusableElementsString ) => {
 	searchForm.classList.toggle( 'is-open' );
 
 	if ( searchForm.classList.contains( 'is-open' ) ) {
-		navigation.classList.add( 'primary-menu--hide-medium' );
+		if ( ! document.body.classList.contains( 'has-header-3' ) ) {
+			navigation.classList.add( 'primary-menu--hide-medium' );
+		}
 		searchForm.querySelector( '.search-form__input' ).removeAttribute( 'tabindex' );
 		searchForm.querySelector( '.search-input__button' ).removeAttribute( 'tabindex' );
 	} else {

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -793,6 +793,8 @@ function search_toggle() {
 		esc_html__( 'Search Toggle', 'go' )
 	);
 
+	get_search_form();
+
 }
 
 /**


### PR DESCRIPTION
Add the missing `get_search_form();` which was removed when we shifted the search form into the template tag `Go\search_toggle()`.

Not necessary if we merge https://github.com/godaddy-wordpress/go/pull/400 