### PR TITLE
Fix submenu item word wrap

### DIFF
--- a/.dev/assets/shared/css/header/sub-menu.css
+++ b/.dev/assets/shared/css/header/sub-menu.css
@@ -72,6 +72,8 @@
 
 		/* All submenu link containers (<li>) */
 		& .menu-item {
+			white-space: normal;
+
 			@media (--large) {
 				display: block;
 				margin-left: 0;


### PR DESCRIPTION
The submenu items are not wrapping properly when longer titles are used. This PR fixes the white space so the words wrap properly in the sub menu.

### Pre-Patch
![image](https://user-images.githubusercontent.com/5321364/67954569-91853280-fbc7-11e9-8723-a121426f8675.png)

### With Patch
![image](https://user-images.githubusercontent.com/5321364/67954456-64388480-fbc7-11e9-86e7-22a093437bb0.png)
