### PR TITLE
Customize the login screen based on user settings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,6 +21,12 @@ require_once get_parent_theme_file_path( 'includes/core.php' );
 require_once get_parent_theme_file_path( 'includes/customizer.php' );
 
 /**
+ * Custom login page.
+ */
+require_once get_parent_theme_file_path( 'includes/login.php' );
+
+
+/**
  * Custom template tags for the theme.
  */
 require_once get_parent_theme_file_path( 'includes/template-tags.php' );
@@ -46,6 +52,7 @@ require_once get_parent_theme_file_path( 'includes/woocommerce.php' );
 Go\Core\setup();
 Go\TGM\setup();
 Go\Customizer\setup();
+Go\Login\setup();
 Go\WooCommerce\setup();
 
 if ( ! function_exists( 'wp_body_open' ) ) :

--- a/includes/login.php
+++ b/includes/login.php
@@ -202,6 +202,6 @@ function customize_login_screen() {
 	<?php
 
 	// Allow output of additional styles without disabling Go login styles.
-	do_action( 'go_enqueue_scripts' );
+	do_action( 'go_login_enqueue_scripts' );
 
 }

--- a/includes/login.php
+++ b/includes/login.php
@@ -29,7 +29,7 @@ function setup() {
 function customize_login_screen() {
 
 	/**
-	 * Filter to preserve disable all login customizations
+	 * Filter to disable all login customizations
 	 *
 	 * @var bool
 	 */

--- a/includes/login.php
+++ b/includes/login.php
@@ -60,6 +60,16 @@ function customize_login_screen() {
 	}
 
 	/**
+	 * Set the login header text
+	 */
+	add_filter(
+		'login_headertext',
+		function() {
+			return get_bloginfo( 'name' );
+		}
+	);
+
+	/**
 	 * Set the login page logo URL
 	 */
 	add_filter(
@@ -100,9 +110,10 @@ function customize_login_screen() {
 
 		body.login div#login h1 a {
 			background-image: url( '<?php echo esc_url( wp_get_attachment_url( get_theme_mod( 'custom_logo' ) ) ); ?>' );
-			background-size: 100%;
+			background-size: contain;
+			background-position: center;
 			height: 150px;
-			width: 150px;
+			width: auto;
 		}
 
 		<?php

--- a/includes/login.php
+++ b/includes/login.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Login customization
+ *
+ * @package Go\Core
+ */
+
+namespace Go\Login;
+
+/**
+ * Set up login features.
+ *
+ * @return void
+ */
+function setup() {
+
+	$n = function( $function ) {
+		return __NAMESPACE__ . "\\$function";
+	};
+
+	add_action( 'login_enqueue_scripts', $n( 'customize_login_screen' ), PHP_INT_MAX );
+
+}
+
+/**
+ * Customize the login screen
+ * Note: Disables when any other function is hooked into login_enqueue_scripts
+ */
+function customize_login_screen() {
+
+	/**
+	 * Filter to preserve disable all login customizations
+	 *
+	 * @var bool
+	 */
+	$disable_customizations = (bool) apply_filters( 'go_disablelogin_customizations', false );
+
+	if ( $disable_customizations ) {
+
+		return;
+
+	}
+
+	/**
+	 * Filter to preserve login customizations
+	 *
+	 * @var bool
+	 */
+	$preserve_customizations = (bool) apply_filters( 'go_preserve_login_customizations', false );
+
+	global $wp_filter;
+
+	if (
+		( 1 < count( $wp_filter['login_enqueue_scripts']->callbacks ) ) &&
+		! $preserve_customizations
+	) {
+
+		return;
+
+	}
+
+	/**
+	 * Set the login page logo URL
+	 */
+	add_filter(
+		'login_headerurl',
+		function() {
+			return site_url();
+		}
+	);
+
+	\Go\Core\styles();
+	\Go\Customizer\inline_css();
+
+	?>
+
+	<style type="text/css">
+	body.login {
+		align-items: center;
+		background: '<?php echo esc_attr( get_background_color() ); ?>';
+		display: flex;
+		justify-content: center;
+	}
+
+	body.login #loginform {
+		border-color: hsl(var(--theme-input--border-color));
+		border-radius: 2px;
+		padding: 26px 24px 35px;
+	}
+
+	body.login div#login {
+		padding: 0;
+	}
+
+	<?php
+
+	if ( has_custom_logo() ) {
+
+		?>
+
+		body.login div#login h1 a {
+			background-image: url( '<?php echo esc_url( wp_get_attachment_url( get_theme_mod( 'custom_logo' ) ) ); ?>' );
+			background-size: 100%;
+			height: 150px;
+			width: 150px;
+		}
+
+		<?php
+
+	} else {
+
+		?>
+
+		body.login div#login h1 {
+			display: none;
+		}
+
+		body.login div#login h1 a {
+			background-image: none;
+		}
+
+		<?php
+
+	}
+
+	?>
+
+	body.login div#login #nav a,
+	body.login div#login #backtoblog a  {
+		color: hsl(var(--theme-link--color, var(--theme-color-primary)));
+		text-decoration: underline;
+	}
+
+	body.login div#login #nav a:hover,
+	body.login div#login #backtoblog a:hover {
+		color: hsl(var(--theme-link--color-interactive, var(--theme-color-text)));
+	}
+
+	body.login div#login input[type="submit"] {
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
+		background: hsl(var(--theme-button--bg));
+		border: none;
+		padding: 0 10px;
+	}
+
+	body.login div#login input[type="submit"]:hover,
+	body.login div#login input[type="submit"]:focus,
+	body.login div#login input[type="submit"]:active {
+		background-color: hsl(var(--theme-button--bg-interactive));
+	}
+
+	body.login div#login .button.wp-hide-pw {
+		color: hsl(var(--theme-label--color));
+	}
+
+	body.login div#login .button.wp-hide-pw:focus {
+		border: none;
+	}
+
+	body.login div#login h1 a:focus,
+	body.login div#login input[type="submit"]:focus,
+	body.login div#login input#rememberme:focus,
+	body.login div#login .button.wp-hide-pw:focus {
+		box-shadow: none;
+		outline-color: hsla(var(--theme-outline-color), 1);
+		outline-style: var(--theme-outline-style, dotted);
+		outline-width: var(--theme-outline-width, 1px);
+	}
+
+	body.login div#login p.submit {
+		display: inline-block;
+		margin-top: 1.25em;
+		width: 100%;
+	}
+
+	body.login div#login p.submit input[type="submit"] {
+		width: 100%;
+	}
+
+	body.login div#login input#rememberme {
+		border-color: hsl(var(--theme-input--border-color));
+	}
+	</style>
+
+	<?php
+
+}

--- a/includes/login.php
+++ b/includes/login.php
@@ -33,7 +33,7 @@ function customize_login_screen() {
 	 *
 	 * @var bool
 	 */
-	$disable_customizations = (bool) apply_filters( 'go_disablelogin_customizations', false );
+	$disable_customizations = (bool) apply_filters( 'go_disable_login_customizations', false );
 
 	if ( $disable_customizations ) {
 

--- a/includes/login.php
+++ b/includes/login.php
@@ -201,4 +201,7 @@ function customize_login_screen() {
 
 	<?php
 
+	// Allow output of additional styles without disabling Go login styles.
+	do_action( 'go_enqueue_scripts' );
+
 }

--- a/includes/login.php
+++ b/includes/login.php
@@ -142,6 +142,10 @@ function customize_login_screen() {
 		text-decoration: underline;
 	}
 
+	body.login div#login label {
+		width: 100%;
+	}
+
 	body.login div#login #nav a:hover,
 	body.login div#login #backtoblog a:hover {
 		color: hsl(var(--theme-link--color-interactive, var(--theme-color-text)));


### PR DESCRIPTION
- Pull in a number of customizations based on the selected design style and color scheme.
- Update the login logo when the user has specified a site logo.
- Hide the WordPress logo on the login page when no site logo is specified.
- Update the styles on the login page to better match that of the front of site.
- All customizations are disabled when any other function hooks into `login_enqueue_scripts`.
   - This allows users to still use login customization plugins or override things with an MU plugin
- Filters are included to allow users to disable the customizations altogether - or in the event something else hooks into `login_enqueue_scripts`, a filter is provided preserve the customizations.
   - `go_disable_login_customizations` - Disable the login customizations altogether.
   - `go_preserve_login_customizations` - Override to preserve customizations even though something else is hooked into `login_enqueue_scripts`.
- Add action `go_login_enqueue_scripts` to allow output of custom styles on the Go styled login page.

### Examples
**Playful, Coral, No Site Logo, Custom Background Color**
![image](https://user-images.githubusercontent.com/5321364/68530904-b7eb5200-02da-11ea-8450-cb6db4ed0cb1.png)

**Traditional, Apricot, No Site Logo**
![image](https://user-images.githubusercontent.com/5321364/68530892-a013ce00-02da-11ea-88f8-8c8c85565198.png)

**Playful, Frolic, Custom Background Color, Custom Site Logo**
![image](https://user-images.githubusercontent.com/5321364/68530887-90948500-02da-11ea-9bbe-5abbdfb00761.png)

**Welcoming, Forest, Custom Logo**
![image](https://user-images.githubusercontent.com/5321364/68530865-68a52180-02da-11ea-9916-c109a5126110.png)
