### PR TITLE
Add an aria-label to the navigation cart link

### DIFF
--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -116,7 +116,7 @@ function woocommerce_cart_link() {
 	 *
 	 * @param string Alt text for the cart menu item.
 	 */
-	$cart_alt_text = (string) esc_html( apply_filters( 'go_menu_cart_alt', __( 'View cart', 'go' ) ) );
+	$cart_alt_text = (string) apply_filters( 'go_menu_cart_alt', __( 'View cart', 'go' ) );
 
 	/**
 	 * Filters the cart menu item text.
@@ -145,9 +145,9 @@ function woocommerce_cart_link() {
 	}
 
 	printf(
-		'<a href="%1$s" class="header__cart-toggle" alt="%2$s">%3$s</a>',
+		'<a href="%1$s" class="header__cart-toggle" alt="%2$s" aria-label="%2$s">%3$s</a>',
 		esc_url( $cart_url ),
-		$cart_alt_text, // @codingStandardsIgnoreLine
+		esc_html( $cart_alt_text ),
 		$cart_text // @codingStandardsIgnoreLine
 	);
 


### PR DESCRIPTION
After running some Lighthouse audits in Chrome, I found that the cart link was throwing an accessibility warning. This PR fixes that warning.

![image](https://user-images.githubusercontent.com/5321364/68531238-59c06e00-02de-11ea-81d9-50b99bb5c294.png)

- I also shifted the `esc_html()` call down so we can remove `// @codingStandardsIgnoreLine` from the one line.