### PR TITLE
Add AMP compatibility

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -408,6 +408,10 @@ function styles() {
  * @link https://git.io/vWdr2
  */
 function skip_link_focus_fix() {
+	if ( is_amp() ) {
+		// This is part of AMP. See <https://github.com/ampproject/amphtml/issues/18671>.
+		return;
+	}
 	// The following is minified via `terser --compress --mangle -- js/skip-link-focus-fix.js`.
 	?>
 	<script>

--- a/includes/core.php
+++ b/includes/core.php
@@ -125,6 +125,15 @@ function theme_setup() {
 		]
 	);
 
+	// Indicate that the theme works well in both Standard and Transitional template modes of the AMP plugin.
+	add_theme_support(
+		'amp',
+		[
+			// The `paired` flag means that the theme retains logic to be fully functional when AMP is disabled.
+			'paired' => true,
+		]
+	);
+
 	// Add support for WooCommerce.
 	add_theme_support( 'woocommerce' );
 	add_theme_support( 'wc-product-gallery-slider' );

--- a/includes/core.php
+++ b/includes/core.php
@@ -311,6 +311,11 @@ function block_editor_assets() {
  */
 function scripts() {
 
+	// Short-circuit in AMP responses since custom scripts are not valid (unless refactored to use  amp-script).
+	if ( is_amp() ) {
+		return;
+	}
+
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
 	wp_enqueue_script(

--- a/includes/core.php
+++ b/includes/core.php
@@ -1245,3 +1245,17 @@ function filter_page_titles( $args ) {
 	return $args;
 
 }
+
+/**
+ * Determine whether it is an AMP response.
+ *
+ * This function is used as a "Conditional Tag" in WordPress. It can only be used at the `wp` action or later.
+ *
+ * @link https://developer.wordpress.org/themes/references/list-of-conditional-tags/
+ * @see is_amp_endpoint()
+ *
+ * @return bool Is AMP response.
+ */
+function is_amp() {
+	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+}


### PR DESCRIPTION
- [x] Add `is_amp()` conditional tag function to check for AMP responses.
- [x] Prevent adding skip-link-focus-fix on AMP responses (since AMP has the IE11 a11y fix built-in).
- [x] Prevent enqueuing scripts in AMP responses.
- [x] Add `amp` theme support to indicate compatibility with Standard and Transitional modes.
- [ ] Implement search toggle.
- [ ] Implement menu toggle.

It appears that the search toggle and menu toggle are both using the logic from Twenty Twenty. Note that the AMP plugin as of 1.4 has its `AMP_Core_Theme_Sanitizer` extended to add AMP-compatibility to those modals (https://github.com/ampproject/amp-wp/pull/3403). So in theory it should be a matter of just re-using that. This was architected by @schlessera who designed it to be used in this way, so he could provide pointers.