### PR TITLE
Remove PHP array shorthand syntax

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -48,10 +48,10 @@ if ( post_password_required() ) {
 			<ol class="commentlist">
 				<?php
 				wp_list_comments(
-					[
+					array(
 						'callback' => 'go_comment',
 						'style'    => 'ol',
-					]
+					)
 				);
 				?>
 			</ol><!-- .commentlist -->

--- a/header.php
+++ b/header.php
@@ -46,10 +46,10 @@
 							<div class="header__navigation-inner">
 								<?php
 								wp_nav_menu(
-									[
+									array(
 										'menu_class'     => 'primary-menu list-reset',
 										'theme_location' => 'primary',
-									]
+									)
 								);
 								?>
 							</div>

--- a/includes/classes/customizer/class-switcher-control.php
+++ b/includes/classes/customizer/class-switcher-control.php
@@ -35,7 +35,7 @@ class Switcher_Control extends \WP_Customize_Control {
 	 * @param string                $id      Control ID.
 	 * @param array                 $args    @see \WP_Customize_Control::__construct().
 	 */
-	public function __construct( \WP_Customize_Manager $manager, $id, $args = [] ) {
+	public function __construct( \WP_Customize_Manager $manager, $id, $args = array() ) {
 		parent::__construct( $manager, $id, $args );
 
 		if ( isset( $args['switcher_type'] ) ) {

--- a/includes/core.php
+++ b/includes/core.php
@@ -79,12 +79,12 @@ function theme_setup() {
 
 	// This theme uses wp_nav_menu() in up to four locations.
 	register_nav_menus(
-		[
+		array(
 			'primary'  => esc_html__( 'Primary', 'go' ),
 			'footer-1' => esc_html__( 'Footer Menu #1', 'go' ),
 			'footer-2' => esc_html__( 'Footer Menu #2', 'go' ),
 			'footer-3' => esc_html__( 'Footer Menu #3', 'go' ),
-		]
+		)
 	);
 
 	/*
@@ -93,13 +93,13 @@ function theme_setup() {
 	 */
 	add_theme_support(
 		'html5',
-		[
+		array(
 			'search-form',
 			'comment-form',
 			'comment-list',
 			'gallery',
 			'caption',
-		]
+		)
 	);
 
 	/**
@@ -109,20 +109,20 @@ function theme_setup() {
 	 */
 	add_theme_support(
 		'custom-logo',
-		[
+		array(
 			'height'      => 190,
 			'width'       => 190,
 			'flex-width'  => true,
 			'flex-height' => true,
-		]
+		)
 	);
 
 	// Add support for custom background color.
 	add_theme_support(
 		'custom-background',
-		[
+		array(
 			'default-color' => \Go\get_palette_color( 'background' ),
-		]
+		)
 	);
 
 	// Add support for WooCommerce.
@@ -146,59 +146,59 @@ function theme_setup() {
 	// Add custom editor font sizes.
 	add_theme_support(
 		'editor-font-sizes',
-		[
-			[
+		array(
+			array(
 				'name'      => esc_html_x( 'Small', 'font size option label', 'go' ),
 				'shortName' => esc_html_x( 'S', 'abbreviation of the font size option label', 'go' ),
 				'size'      => 17,
 				'slug'      => 'small',
-			],
-			[
+			),
+			array(
 				'name'      => esc_html_x( 'Medium', 'font size option label', 'go' ),
 				'shortName' => esc_html_x( 'M', 'abbreviation of the font size option label', 'go' ),
 				'size'      => 21,
 				'slug'      => 'medium',
-			],
-			[
+			),
+			array(
 				'name'      => esc_html_x( 'Large', 'font size option label', 'go' ),
 				'shortName' => esc_html_x( 'L', 'abbreviation of the font size option label', 'go' ),
 				'size'      => 24,
 				'slug'      => 'large',
-			],
-			[
+			),
+			array(
 				'name'      => esc_html_x( 'Huge', 'font size option label', 'go' ),
 				'shortName' => esc_html_x( 'XL', 'abbreviation of the font size option label', 'go' ),
 				'size'      => 30,
 				'slug'      => 'huge',
-			],
-		]
+			),
+		)
 	);
 
 	$design_style = get_design_style();
 
 	if ( $design_style ) {
-		$color_palette = [
-			[
+		$color_palette = array(
+			array(
 				'name'  => esc_html_x( 'Primary', 'name of the first color palette selection', 'go' ),
 				'slug'  => 'primary',
 				'color' => \Go\get_palette_color( 'primary' ),
-			],
-			[
+			),
+			array(
 				'name'  => esc_html_x( 'Secondary', 'name of the second color palette selection', 'go' ),
 				'slug'  => 'secondary',
 				'color' => \Go\get_palette_color( 'secondary' ),
-			],
-			[
+			),
+			array(
 				'name'  => esc_html_x( 'Tertiary', 'name of the third color palette selection', 'go' ),
 				'slug'  => 'tertiary',
 				'color' => \Go\get_palette_color( 'tertiary' ),
-			],
-			[
+			),
+			array(
 				'name'  => esc_html_x( 'Quaternary', 'name of the fourth color palette selection', 'go' ),
 				'slug'  => 'quaternary',
 				'color' => '#ffffff',
-			],
-		];
+			),
+		);
 
 		add_theme_support( 'editor-color-palette', $color_palette );
 	}
@@ -227,7 +227,7 @@ function fonts_url() {
 
 	}
 
-	$fonts = [];
+	$fonts = array();
 
 	foreach ( $design_styles[ $design_style ]['fonts'] as $font => $font_weights ) {
 
@@ -237,7 +237,7 @@ function fonts_url() {
 
 	if ( is_customize_preview() ) {
 
-		$fonts = [];
+		$fonts = array();
 
 		foreach ( $design_styles as $design_style => $data ) {
 
@@ -257,10 +257,10 @@ function fonts_url() {
 
 	return esc_url_raw(
 		add_query_arg(
-			[
+			array(
 				'family' => rawurlencode( implode( '|', $fonts ) ),
 				'subset' => rawurlencode( 'latin,latin-ext' ),
-			],
+			),
 			'https://fonts.googleapis.com/css'
 		)
 	);
@@ -283,7 +283,7 @@ function block_editor_assets() {
 	wp_enqueue_script(
 		'go-block-filters',
 		get_theme_file_uri( "dist/js/admin/block-filters{$suffix}.js" ),
-		[ 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ],
+		array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ),
 		GO_VERSION,
 		true
 	);
@@ -297,9 +297,9 @@ function block_editor_assets() {
 	wp_localize_script(
 		'go-block-filters',
 		'GoBlockFilters',
-		[
+		array(
 			'inlineStyles' => $styles,
-		]
+		)
 	);
 
 }
@@ -316,7 +316,7 @@ function scripts() {
 	wp_enqueue_script(
 		'go-frontend',
 		get_theme_file_uri( "dist/js/frontend{$suffix}.js" ),
-		[],
+		array(),
 		GO_VERSION,
 		true
 	);
@@ -324,9 +324,9 @@ function scripts() {
 	wp_localize_script(
 		'go-frontend',
 		'GoText',
-		[
+		array(
 			'searchLabel' => esc_html__( 'Expand search field', 'go' ),
-		]
+		)
 	);
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
@@ -375,7 +375,7 @@ function styles() {
 	wp_enqueue_style(
 		'go-style',
 		get_theme_file_uri( "dist/css/style-shared{$suffix}.css" ),
-		[ 'go-fonts' ],
+		array( 'go-fonts' ),
 		GO_VERSION
 	);
 
@@ -385,7 +385,7 @@ function styles() {
 		wp_enqueue_style(
 			'go-design-style-' . $design_style['slug'],
 			$design_style['url'],
-			[ 'go-style' ],
+			array( 'go-style' ),
 			GO_VERSION
 		);
 	}
@@ -393,7 +393,7 @@ function styles() {
 	wp_enqueue_style(
 		'go-fonts',
 		fonts_url(),
-		[],
+		array(),
 		GO_VERSION
 	);
 
@@ -557,179 +557,179 @@ function get_available_design_styles() {
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
-	$default_design_styles = [
-		'traditional' => [
+	$default_design_styles = array(
+		'traditional' => array(
 			'slug'          => 'traditional',
 			'label'         => _x( 'Traditional', 'design style name', 'go' ),
 			'url'           => get_theme_file_uri( "dist/css/design-styles/style-traditional{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-traditional-editor{$suffix}.css",
-			'color_schemes' => [
-				'one'   => [
+			'color_schemes' => array(
+				'one'   => array(
 					'label'      => _x( 'Apricot', 'color palette name', 'go' ),
 					'primary'    => '#c76919',
 					'secondary'  => '#122538',
 					'tertiary'   => '#f8f8f8',
 					'background' => '#ffffff',
-				],
-				'two'   => [
+				),
+				'two'   => array(
 					'label'      => _x( 'Emerald', 'color palette name', 'go' ),
 					'primary'    => '#165153',
 					'secondary'  => '#212121',
 					'tertiary'   => '#f3f1f0',
 					'background' => '#ffffff',
-				],
-				'three' => [
+				),
+				'three' => array(
 					'label'      => _x( 'Brick', 'color palette name', 'go' ),
 					'primary'    => '#87200e',
 					'secondary'  => '#242611',
 					'tertiary'   => '#f9f2ef',
 					'background' => '#ffffff',
-				],
-				'four'  => [
+				),
+				'four'  => array(
 					'label'      => _x( 'Bronze', 'color palette name', 'go' ),
 					'primary'    => '#a88548',
 					'secondary'  => '#05212d',
 					'tertiary'   => '#f9f4ef',
 					'background' => '#ffffff',
-				],
-			],
-			'fonts'         => [
-				'Crimson Text' => [
+				),
+			),
+			'fonts'         => array(
+				'Crimson Text' => array(
 					'400',
 					'400i',
 					'700',
 					'700i',
-				],
-				'Nunito Sans'  => [
+				),
+				'Nunito Sans'  => array(
 					'400',
 					'400i',
 					'600',
 					'700',
-				],
-			],
-		],
-		'modern'      => [
+				),
+			),
+		),
+		'modern'      => array(
 			'slug'          => 'modern',
 			'label'         => _x( 'Modern', 'design style name', 'go' ),
 			'url'           => get_theme_file_uri( "dist/css/design-styles/style-modern{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-modern-editor{$suffix}.css",
-			'color_schemes' => [
-				'one'   => [
+			'color_schemes' => array(
+				'one'   => array(
 					'label'      => _x( 'Shade', 'color palette name', 'go' ),
 					'primary'    => '#000000',
 					'secondary'  => '#455a64',
 					'tertiary'   => '#eceff1',
 					'background' => '#ffffff',
-				],
-				'two'   => [
+				),
+				'two'   => array(
 					'label'      => _x( 'Blush', 'color palette name', 'go' ),
 					'primary'    => '#c2185b',
 					'secondary'  => '#ec407a',
 					'tertiary'   => '#fce4ec',
 					'background' => '#ffffff',
-				],
-				'three' => [
+				),
+				'three' => array(
 					'label'      => _x( 'Indigo', 'color palette name', 'go' ),
 					'primary'    => '#303f9f',
 					'secondary'  => '#5c6bc0',
 					'tertiary'   => '#e8eaf6',
 					'background' => '#ffffff',
-				],
-				'four'  => [
+				),
+				'four'  => array(
 					'label'      => _x( 'Pacific', 'color palette name', 'go' ),
 					'primary'    => '#00796b',
 					'secondary'  => '#26a69a',
 					'tertiary'   => '#e0f2f1',
 					'background' => '#ffffff',
-				],
-			],
-			'fonts'         => [
-				'Montserrat' => [
+				),
+			),
+			'fonts'         => array(
+				'Montserrat' => array(
 					'400',
 					'700',
-				],
-				'Fira Code'  => [
+				),
+				'Fira Code'  => array(
 					'400',
 					'400i',
 					'700',
-				],
-				'Heebo'      => [
+				),
+				'Heebo'      => array(
 					'400',
 					'800',
-				],
-			],
-		],
-		'trendy'      => [
+				),
+			),
+		),
+		'trendy'      => array(
 			'slug'          => 'trendy',
 			'label'         => _x( 'Trendy', 'design style name', 'go' ),
 			'url'           => get_theme_file_uri( "dist/css/design-styles/style-trendy{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-trendy-editor{$suffix}.css",
-			'color_schemes' => [
-				'one'   => [
+			'color_schemes' => array(
+				'one'   => array(
 					'label'             => _x( 'Plum', 'color palette name', 'go' ),
 					'primary'           => '#000000',
 					'secondary'         => '#4d0859',
 					'tertiary'          => '#ded9e2',
 					'background'        => '#ffffff',
 					'footer_background' => '#000000',
-				],
+				),
 
-				'two'   => [
+				'two'   => array(
 					'label'             => _x( 'Steel', 'color palette name', 'go' ),
 					'primary'           => '#000000',
 					'secondary'         => '#003c68',
 					'tertiary'          => '#c0c9d0',
 					'background'        => '#ffffff',
 					'footer_background' => '#000000',
-				],
-				'three' => [
+				),
+				'three' => array(
 					'label'             => _x( 'Avocado', 'color palette name', 'go' ),
 					'primary'           => '#000000',
 					'secondary'         => '#02493b',
 					'tertiary'          => '#b4c6af',
 					'background'        => '#ffffff',
 					'footer_background' => '#000000',
-				],
-				'four'  => [
+				),
+				'four'  => array(
 					'label'             => _x( 'Champagne', 'color palette name', 'go' ),
 					'primary'           => '#000000',
 					'secondary'         => '#cc224f',
 					'tertiary'          => '#e5dede',
 					'background'        => '#ffffff',
 					'footer_background' => '#000000',
-				],
-			],
-			'fonts'         => [
-				'Trocchi'         => [
+				),
+			),
+			'fonts'         => array(
+				'Trocchi'         => array(
 					'400',
 					'600',
-				],
-				'Noto Sans'       => [
+				),
+				'Noto Sans'       => array(
 					'400',
 					'400i',
 					'700',
-				],
-				'Source Code Pro' => [
+				),
+				'Source Code Pro' => array(
 					'400',
 					'700',
-				],
-			],
-		],
-		'welcoming'   => [
+				),
+			),
+		),
+		'welcoming'   => array(
 			'slug'          => 'welcoming',
 			'label'         => _x( 'Welcoming', 'design style name', 'go' ),
 			'url'           => get_theme_file_uri( "dist/css/design-styles/style-welcoming{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-welcoming-editor{$suffix}.css",
-			'color_schemes' => [
-				'one'   => [
+			'color_schemes' => array(
+				'one'   => array(
 					'label'             => _x( 'Forest', 'color palette name', 'go' ),
 					'primary'           => '#165144',
 					'secondary'         => '#01332e',
 					'tertiary'          => '#c9c9c9',
 					'background'        => '#eeeeee',
 					'header_background' => '#ffffff',
-				],
-				'two'   => [
+				),
+				'two'   => array(
 					'label'             => _x( 'Spruce', 'color palette name', 'go' ),
 					'primary'           => '#233a6b',
 					'secondary'         => '#01133d',
@@ -737,43 +737,43 @@ function get_available_design_styles() {
 					'background'        => '#ffffff',
 					'background'        => '#eeeeee',
 					'header_background' => '#ffffff',
-				],
-				'three' => [
+				),
+				'three' => array(
 					'label'             => _x( 'Mocha', 'color palette name', 'go' ),
 					'primary'           => '#5b3f20',
 					'secondary'         => '#3f2404',
 					'tertiary'          => '#c9c9c9',
 					'background'        => '#eeeeee',
 					'header_background' => '#ffffff',
-				],
-				'four'  => [
+				),
+				'four'  => array(
 					'label'             => _x( 'Lavender', 'color palette name', 'go' ),
 					'primary'           => '#443a82',
 					'secondary'         => '#2b226b',
 					'tertiary'          => '#c9c9c9',
 					'background'        => '#eeeeee',
 					'header_background' => '#ffffff',
-				],
-			],
-			'fonts'         => [
-				'Work Sans' => [
+				),
+			),
+			'fonts'         => array(
+				'Work Sans' => array(
 					'300',
 					'700',
-				],
-				'Karla'     => [
+				),
+				'Karla'     => array(
 					'400',
 					'400i',
 					'700',
-				],
-			],
-		],
-		'playful'     => [
+				),
+			),
+		),
+		'playful'     => array(
 			'slug'          => 'playful',
 			'label'         => _x( 'Playful', 'design style name', 'go' ),
 			'url'           => get_theme_file_uri( "dist/css/design-styles/style-playful{$suffix}.css" ),
 			'editor_style'  => "dist/css/design-styles/style-playful-editor{$suffix}.css",
-			'color_schemes' => [
-				'one'   => [
+			'color_schemes' => array(
+				'one'   => array(
 					'label'             => _x( 'Frolic', 'color palette name', 'go' ),
 					'primary'           => '#3f46ae',
 					'secondary'         => '#ecb43d',
@@ -782,8 +782,8 @@ function get_available_design_styles() {
 					'header_background' => '#3f46ae',
 					'header_text'       => '#fafafa',
 					'footer_background' => '#3f46ae',
-				],
-				'two'   => [
+				),
+				'two'   => array(
 					'label'             => _x( 'Coral', 'color palette name', 'go' ),
 					'primary'           => '#e06b6d',
 					'secondary'         => '#40896e',
@@ -792,8 +792,8 @@ function get_available_design_styles() {
 					'header_background' => '#eb616a',
 					'header_text'       => '#fafafa',
 					'footer_background' => '#eb616a',
-				],
-				'three' => [
+				),
+				'three' => array(
 					'label'             => _x( 'Organic', 'color palette name', 'go' ),
 					'primary'           => '#3c896d',
 					'secondary'         => '#6b0369',
@@ -802,8 +802,8 @@ function get_available_design_styles() {
 					'header_background' => '#3c896d',
 					'header_text'       => '#fafafa',
 					'footer_background' => '#3c896d',
-				],
-				'four'  => [
+				),
+				'four'  => array(
 					'label'             => _x( 'Berry', 'color palette name', 'go' ),
 					'primary'           => '#117495',
 					'secondary'         => '#d691c1',
@@ -812,19 +812,19 @@ function get_available_design_styles() {
 					'header_background' => '#117495',
 					'header_text'       => '#fafafa',
 					'footer_background' => '#117495',
-				],
-			],
-			'fonts'         => [
-				'Quicksand' => [
+				),
+			),
+			'fonts'         => array(
+				'Quicksand' => array(
 					'400',
 					'600',
-				],
-				'Poppins'   => [
+				),
+				'Poppins'   => array(
 					'700',
-				],
-			],
-		],
-	];
+				),
+			),
+		),
+	);
 
 	/**
 	 * Filters the supported design styles.
@@ -884,36 +884,36 @@ function get_default_header_variation() {
  * @return array
  */
 function get_available_header_variations() {
-	$default_header_variations = [
-		'header-1' => [
+	$default_header_variations = array(
+		'header-1' => array(
 			'label'         => esc_html_x( 'Header 1', 'name of the first header variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-1.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '1' );
 			},
-		],
-		'header-2' => [
+		),
+		'header-2' => array(
 			'label'         => esc_html_x( 'Header 2', 'name of the second header variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-2.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '2' );
 			},
-		],
-		'header-3' => [
+		),
+		'header-3' => array(
 			'label'         => esc_html_x( 'Header 3', 'name of the third header variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-3.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '3' );
 			},
-		],
-		'header-4' => [
+		),
+		'header-4' => array(
 			'label'         => esc_html_x( 'Header 4', 'name of the fourth header variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/header-4.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/headers/header', '4' );
 			},
-		],
-	];
+		),
+	);
 
 	/**
 	 * Filters the supported header variations.
@@ -953,36 +953,36 @@ function get_header_variation() {
  * @return array
  */
 function get_available_footer_variations() {
-	$default_footer_variations = [
-		'footer-1' => [
+	$default_footer_variations = array(
+		'footer-1' => array(
 			'label'         => esc_html_x( 'Footer 1', 'name of the first footer variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-1.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '1' );
 			},
-		],
-		'footer-2' => [
+		),
+		'footer-2' => array(
 			'label'         => esc_html_x( 'Footer 2', 'name of the second footer variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-2.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '2' );
 			},
-		],
-		'footer-3' => [
+		),
+		'footer-3' => array(
 			'label'         => esc_html_x( 'Footer 3', 'name of the third footer variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-3.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '3' );
 			},
-		],
-		'footer-4' => [
+		),
+		'footer-4' => array(
 			'label'         => esc_html_x( 'Footer 4', 'name of the fourth footer variation option', 'go' ),
 			'preview_image' => get_theme_file_uri( 'dist/images/admin/footer-4.svg' ),
 			'partial'       => function() {
 				return get_template_part( 'partials/footers/footer', '4' );
 			},
-		],
-	];
+		),
+	);
 
 	/**
 	 * Filters the supported header variations.
@@ -1057,33 +1057,33 @@ function get_default_copyright() {
  * @return array
  */
 function get_available_social_icons() {
-	$social_icons = [
-		'facebook'  => [
+	$social_icons = array(
+		'facebook'  => array(
 			'label'       => esc_html__( 'Facebook', 'go' ),
 			'icon'        => get_theme_file_path( 'dist/images/social/facebook.svg' ),
 			'placeholder' => 'https://facebook.com/user',
-		],
-		'twitter'   => [
+		),
+		'twitter'   => array(
 			'label'       => esc_html__( 'Twitter', 'go' ),
 			'icon'        => get_theme_file_path( 'dist/images/social/twitter.svg' ),
 			'placeholder' => 'https://twitter.com/user',
-		],
-		'instagram' => [
+		),
+		'instagram' => array(
 			'label'       => esc_html__( 'Instagram', 'go' ),
 			'icon'        => get_theme_file_path( 'dist/images/social/instagram.svg' ),
 			'placeholder' => 'https://instagram.com/user',
-		],
-		'linkedin'  => [
+		),
+		'linkedin'  => array(
 			'label'       => esc_html__( 'LinkedIn', 'go' ),
 			'icon'        => get_theme_file_path( 'dist/images/social/linkedin.svg' ),
 			'placeholder' => 'https://linkedin.com/in/user',
-		],
-		'pinterest' => [
+		),
+		'pinterest' => array(
 			'label'       => esc_html__( 'Pinterest', 'go' ),
 			'icon'        => get_theme_file_path( 'dist/images/social/pinterest.svg' ),
 			'placeholder' => 'https://pinterest.com/user',
-		],
-	];
+		),
+	);
 
 	/**
 	 * Filters the supported social icons.

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -72,11 +72,11 @@ function wp_nav_fallback( $args ) {
 	$instance_id = $args['customize_preview_nav_menus_args']['args_hmac'];
 	$attributes  = '';
 
-	$attrs = [
+	$attrs = array(
 		'data-customize-partial-id'                => 'nav_menu_instance[' . esc_attr( $instance_id ) . ']',
 		'data-customize-partial-type'              => 'nav_menu_instance',
 		'data-customize-partial-placement-context' => esc_attr( wp_json_encode( $args['customize_preview_nav_menus_args'] ) ),
-	];
+	);
 
 	$attributes = implode(
 		' ',
@@ -128,25 +128,25 @@ function default_controls( \WP_Customize_Manager $wp_customize ) {
 	if ( isset( $wp_customize->selective_refresh ) ) {
 		$wp_customize->selective_refresh->add_partial(
 			'blogname',
-			[
+			array(
 				'selector'        => '.header__titles',
 				'render_callback' => '\\Go\\site_branding',
-			]
+			)
 		);
 		$wp_customize->selective_refresh->add_partial(
 			'blogdescription',
-			[
+			array(
 				'selector'        => '.header__titles',
 				'render_callback' => '\\Go\\site_branding',
-			]
+			)
 		);
 
 		$wp_customize->selective_refresh->add_partial(
 			'custom_logo',
-			[
+			array(
 				'selector'        => '.header__titles',
 				'render_callback' => '\\Go\\site_branding',
-			]
+			)
 		);
 	}
 
@@ -165,7 +165,7 @@ function customize_preview_init() {
 	wp_enqueue_script(
 		'go-customize-preview',
 		get_theme_file_uri( "dist/js/admin/customize-preview{$suffix}.js" ),
-		[ 'jquery', 'customize-preview', 'wp-autop' ],
+		array( 'jquery', 'customize-preview', 'wp-autop' ),
 		GO_VERSION,
 		true
 	);
@@ -173,9 +173,9 @@ function customize_preview_init() {
 	wp_localize_script(
 		'go-customize-preview',
 		'GoPreviewData',
-		[
+		array(
 			'design_styles' => \Go\Core\get_available_design_styles(),
-		]
+		)
 	);
 }
 
@@ -191,7 +191,7 @@ function enqueue_controls_assets() {
 	wp_enqueue_script(
 		'go-customize-controls',
 		get_theme_file_uri( "dist/js/admin/customize-controls{$suffix}.js" ),
-		[ 'jquery' ],
+		array( 'jquery' ),
 		GO_VERSION,
 		true
 	);
@@ -199,7 +199,7 @@ function enqueue_controls_assets() {
 	wp_enqueue_style(
 		'go-customize-style',
 		get_theme_file_uri( "dist/css/admin/style-customize{$suffix}.css" ),
-		[],
+		array(),
 		GO_VERSION
 	);
 }
@@ -212,7 +212,7 @@ function enqueue_controls_assets() {
  */
 function get_color_schemes_as_choices() {
 	$design_styles = \Go\Core\get_available_design_styles();
-	$color_schemes = [];
+	$color_schemes = array();
 
 	array_walk(
 		$design_styles,
@@ -240,59 +240,59 @@ function register_logo_controls( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_setting(
 		'logo_width',
-		[
+		array(
 			'default'           => 100,
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'absint',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new Range_Control(
 			$wp_customize,
 			'logo_width',
-			[
+			array(
 				'default'     => 100,
 				'type'        => 'go_range_control',
 				'label'       => esc_html__( 'Width', 'go' ),
 				'description' => 'px',
 				'section'     => 'title_tagline',
 				'priority'    => 8,
-				'input_attrs' => [
+				'input_attrs' => array(
 					'min'  => 40,
 					'max'  => 300,
 					'step' => 2,
-				],
-			]
+				),
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'logo_width_mobile',
-		[
+		array(
 			'default'           => 100,
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'absint',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new Range_Control(
 			$wp_customize,
 			'logo_width_mobile',
-			[
+			array(
 				'default'     => 100,
 				'type'        => 'go_range_control',
 				'label'       => esc_html__( 'Mobile Width', 'go' ),
 				'description' => 'px',
 				'section'     => 'title_tagline',
 				'priority'    => 9,
-				'input_attrs' => [
+				'input_attrs' => array(
 					'min'  => 40,
 					'max'  => 200,
 					'step' => 2,
-				],
-			]
+				),
+			)
 		)
 	);
 }
@@ -308,49 +308,49 @@ function register_global_controls( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_section(
 		'go_site_settings',
-		[
+		array(
 			'title'    => esc_html__( 'Site Settings', 'go' ),
 			'priority' => 100,
-		]
+		)
 	);
 
 	$wp_customize->add_setting(
 		'page_titles',
-		[
+		array(
 			'default'           => true,
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'absint',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		'show_page_title_checkbox',
-		[
+		array(
 			'label'       => esc_html__( 'Page Titles', 'go' ),
 			'description' => esc_html__( 'Display page titles on individual pages.', 'go' ),
 			'section'     => 'go_site_settings',
 			'settings'    => 'page_titles',
 			'type'        => 'checkbox',
-		]
+		)
 	);
 
 	$wp_customize->add_setting(
 		'copyright',
-		[
+		array(
 			'default'           => \Go\Core\get_default_copyright(),
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_text_field',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		'copyright_control',
-		[
+		array(
 			'label'    => esc_html__( 'Copyright Text', 'go' ),
 			'section'  => 'go_site_settings',
 			'settings' => 'copyright',
 			'type'     => 'text',
-		]
+		)
 	);
 }
 
@@ -365,16 +365,16 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_setting(
 		'design_style',
-		[
+		array(
 			'default'           => \Go\Core\get_default_design_style(),
 			'transport'         => 'postMessage',
 			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_radio',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		'design_style_control',
-		[
+		array(
 			'label'       => esc_html__( 'Design Style', 'go' ),
 			'description' => esc_html__( 'Choose a style, select a color scheme and customize colors to personalize your site.', 'go' ),
 			'section'     => 'colors',
@@ -382,96 +382,96 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 			'type'        => 'radio',
 			'choices'     => wp_list_pluck( \Go\Core\get_available_design_styles(), 'label' ),
 			'priority'    => 1,
-		]
+		)
 	);
 
 	$wp_customize->add_setting(
 		'color_scheme',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'default'           => \Go\Core\get_default_color_scheme(),
 			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_radio',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new Switcher_Control(
 			$wp_customize,
 			'color_scheme_control',
-			[
+			array(
 				'label'         => esc_html__( 'Color Scheme', 'go' ),
 				'section'       => 'colors',
 				'settings'      => 'color_scheme',
 				'choices'       => get_color_schemes_as_choices(),
 				'switcher_type' => 'color-scheme',
 				'priority'      => 1,
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'primary_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'default'           => \Go\get_default_palette_color( 'primary' ),
 			'sanitize_callback' => 'sanitize_hex_color',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'primary_color_control',
-			[
+			array(
 				'label'    => esc_html__( 'Primary', 'go' ),
 				'section'  => 'colors',
 				'settings' => 'primary_color',
 				'priority' => 1,
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'secondary_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'default'           => \Go\get_default_palette_color( 'secondary' ),
 			'sanitize_callback' => 'sanitize_hex_color',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'secondary_color_control',
-			[
+			array(
 				'label'    => esc_html__( 'Secondary', 'go' ),
 				'section'  => 'colors',
 				'settings' => 'secondary_color',
 				'priority' => 1,
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'tertiary_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'default'           => \Go\get_default_palette_color( 'tertiary' ),
 			'sanitize_callback' => 'sanitize_hex_color',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'tertiary_color_control',
-			[
+			array(
 				'label'    => esc_html__( 'Tertiary', 'go' ),
 				'section'  => 'colors',
 				'settings' => 'tertiary_color',
 				'priority' => 1,
-			]
+			)
 		)
 	);
 }
@@ -487,73 +487,73 @@ function register_header_controls( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_section(
 		'go_header_settings',
-		[
+		array(
 			'title'    => esc_html__( 'Header', 'go' ),
 			'priority' => 70,
-		]
+		)
 	);
 
 	$wp_customize->add_setting(
 		'header_variation',
-		[
+		array(
 			'default'           => \Go\Core\get_default_header_variation(),
 			'transport'         => 'postMessage',
 			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_radio',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new Switcher_Control(
 			$wp_customize,
 			'header_variation_control',
-			[
+			array(
 				'label'       => esc_html__( 'Header', 'go' ),
 				'description' => esc_html__( 'Choose a header for every page on your site, then style it with the selectors below.', 'go' ),
 				'section'     => 'go_header_settings',
 				'settings'    => 'header_variation',
 				'choices'     => \Go\Core\get_available_header_variations(),
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'header_background_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_hex_color',
 			'default'           => \Go\get_default_palette_color( 'header_background' ),
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'header_background_color_control',
-			[
+			array(
 				'label'    => esc_html__( 'Background Color', 'go' ),
 				'section'  => 'go_header_settings',
 				'settings' => 'header_background_color',
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'header_text_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_hex_color',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'header_text_color_control',
-			[
+			array(
 				'label'    => esc_html__( 'Text Color', 'go' ),
 				'section'  => 'go_header_settings',
 				'settings' => 'header_text_color',
-			]
+			)
 		)
 	);
 }
@@ -569,93 +569,93 @@ function register_footer_controls( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_section(
 		'go_footer_settings',
-		[
+		array(
 			'title'    => esc_html__( 'Footer', 'go' ),
 			'priority' => 90,
-		]
+		)
 	);
 
 	$wp_customize->add_setting(
 		'footer_variation',
-		[
+		array(
 			'default'           => \Go\Core\get_default_footer_variation(),
 			'transport'         => 'postMessage',
 			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_radio',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new Switcher_Control(
 			$wp_customize,
 			'footer_variation_control',
-			[
+			array(
 				'label'       => esc_html__( 'Footer', 'go' ),
 				'description' => esc_html__( 'Choose a footer for every page on your site, then style it with the selectors below.', 'go' ),
 				'section'     => 'go_footer_settings',
 				'settings'    => 'footer_variation',
 				'choices'     => \Go\Core\get_available_footer_variations(),
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'footer_background_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_hex_color',
 			'default'           => \Go\get_default_palette_color( 'footer_background' ),
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'footer_background_color_control',
-			[
+			array(
 				'label'    => esc_html__( 'Background Color', 'go' ),
 				'section'  => 'go_footer_settings',
 				'settings' => 'footer_background_color',
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'footer_heading_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_hex_color',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'footer_heading_color',
-			[
+			array(
 				'label'    => esc_html__( 'Heading Color', 'go' ),
 				'section'  => 'go_footer_settings',
 				'settings' => 'footer_heading_color',
-			]
+			)
 		)
 	);
 
 	$wp_customize->add_setting(
 		'footer_text_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_hex_color',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'footer_text_color',
-			[
+			array(
 				'label'    => esc_html__( 'Text Color', 'go' ),
 				'section'  => 'go_footer_settings',
 				'settings' => 'footer_text_color',
-			]
+			)
 		)
 	);
 }
@@ -671,11 +671,11 @@ function register_social_controls( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_section(
 		'go_social_media',
-		[
+		array(
 			'title'       => esc_html__( 'Social', 'go' ),
 			'description' => 'Add social media account links to apply social icons to the footer of your site.',
 			'priority'    => 90,
-		]
+		)
 	);
 
 	$social_icons = \Go\Core\get_available_social_icons();
@@ -683,43 +683,43 @@ function register_social_controls( \WP_Customize_Manager $wp_customize ) {
 	foreach ( $social_icons as $key => $social_icon ) {
 		$wp_customize->add_setting(
 			sprintf( 'social_icon_%s', $key ),
-			[
+			array(
 				'transport'         => 'postMessage',
 				'sanitize_callback' => 'esc_url_raw',
-			]
+			)
 		);
 
 		$wp_customize->add_control(
 			sprintf( 'social_icon_%s_control', $key ),
-			[
+			array(
 				'label'       => $social_icon['label'],
 				'section'     => 'go_social_media',
 				'settings'    => sprintf( 'social_icon_%s', $key ),
 				'type'        => 'url',
-				'input_attrs' => [
+				'input_attrs' => array(
 					'placeholder' => esc_url( $social_icon['placeholder'] ),
-				],
-			]
+				),
+			)
 		);
 	}
 
 	$wp_customize->add_setting(
 		'social_icon_color',
-		[
+		array(
 			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_hex_color',
-		]
+		)
 	);
 
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
 			'social_icon_color',
-			[
+			array(
 				'label'    => esc_html__( 'Icon Color', 'go' ),
 				'section'  => 'go_social_media',
 				'settings' => 'social_icon_color',
-			]
+			)
 		)
 	);
 }

--- a/includes/pluggable.php
+++ b/includes/pluggable.php
@@ -67,12 +67,12 @@ if ( ! function_exists( 'go_comment' ) ) :
 				comment_reply_link(
 					array_merge(
 						$args,
-						[
+						array(
 							'reply_text' => __( 'Reply', 'go' ),
 							'after'      => ' <span>&darr;</span>',
 							'depth'      => $depth,
 							'max_depth'  => $args['max_depth'],
-						]
+						)
 					)
 				);
 				?>

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -40,7 +40,7 @@ function get_post_meta( $post_id = null, $location = 'top' ) {
 	$page_template = get_page_template_slug( $post_id );
 
 	// Check whether the post type is allowed to output post meta.
-	$disallowed_post_types = apply_filters( 'go_disallowed_post_types_for_meta_output', [ 'page' ] );
+	$disallowed_post_types = apply_filters( 'go_disallowed_post_types_for_meta_output', array( 'page' ) );
 	if ( in_array( get_post_type( $post_id ), $disallowed_post_types, true ) ) {
 		return;
 	}
@@ -53,12 +53,12 @@ function get_post_meta( $post_id = null, $location = 'top' ) {
 
 		$post_meta                 = apply_filters(
 			'go_post_meta_location_single_top',
-			[
+			array(
 				'author',
 				'post-date',
 				'comments',
 				'sticky',
-			]
+			)
 		);
 		$post_meta_wrapper_classes = ' post__meta--single post__meta--top';
 
@@ -66,9 +66,9 @@ function get_post_meta( $post_id = null, $location = 'top' ) {
 
 		$post_meta                 = apply_filters(
 			'go_post_meta_location_single_bottom',
-			[
+			array(
 				'tags',
-			]
+			)
 		);
 		$post_meta_wrapper_classes = ' post__meta--single post__meta--single-bottom';
 
@@ -139,11 +139,11 @@ function get_post_meta( $post_id = null, $location = 'top' ) {
 									),
 									array_merge(
 										wp_kses_allowed_html( 'post' ),
-										[
-											'time' => [
+										array(
+											'time' => array(
 												'datetime' => true,
-											],
-										]
+											),
+										)
 									)
 								);
 								?>
@@ -259,14 +259,14 @@ function get_post_meta( $post_id = null, $location = 'top' ) {
 function get_palette_color( $color, $format = 'RBG' ) {
 	$default         = \Go\Core\get_default_color_scheme();
 	$color_scheme    = get_theme_mod( 'color_scheme', $default );
-	$override_colors = [
+	$override_colors = array(
 		'primary'           => 'primary_color',
 		'secondary'         => 'secondary_color',
 		'tertiary'          => 'tertiary_color',
 		'background'        => 'background_color',
 		'header_background' => 'header_background_color',
 		'footer_background' => 'footer_background_color',
-	];
+	);
 
 	$color_override = get_theme_mod( $override_colors[ $color ] );
 
@@ -337,10 +337,10 @@ function get_default_palette_color( $color, $format = 'RBG' ) {
  */
 function hex_to_hsl( $hex, $string_output = false ) {
 	if ( empty( $hex ) ) {
-		return $string_output ? '' : [ '', '', '' ];
+		return $string_output ? '' : array( '', '', '' );
 	}
 
-	$hex = [ $hex[1] . $hex[2], $hex[3] . $hex[4], $hex[5] . $hex[6] ];
+	$hex = array( $hex[1] . $hex[2], $hex[3] . $hex[4], $hex[5] . $hex[6] );
 	$rgb = array_map(
 		function( $part ) {
 			return intval( hexdec( $part ) ) / 255.0;
@@ -380,7 +380,7 @@ function hex_to_hsl( $hex, $string_output = false ) {
 		return "{$h}, {$s}%, ${l}%";
 	}
 
-	return [ $h, $s, $l ];
+	return array( $h, $s, $l );
 }
 
 /**
@@ -440,30 +440,30 @@ function has_footer_background() {
  *
  * @return void
  */
-function copyright( $args = [] ) {
+function copyright( $args = array() ) {
 
 	$args = wp_parse_args(
 		$args,
-		[
+		array(
 			'class' => 'site-info',
-		]
+		)
 	);
 
-	$year      = sprintf( '&copy; %s&nbsp;', esc_html( date( 'Y' ) ) );
+	$year      = sprintf( '&copy; %s&nbsp;', esc_html( gmdate( 'Y' ) ) );
 	$copyright = get_theme_mod( 'copyright', \Go\Core\get_default_copyright() );
 
-	$html = [
-		'div'  => [
-			'class' => [],
-		],
-		'span' => [
-			'class' => [],
-		],
-		'a'    => [
-			'href'  => [],
-			'class' => [],
-		],
-	];
+	$html = array(
+		'div'  => array(
+			'class' => array(),
+		),
+		'span' => array(
+			'class' => array(),
+		),
+		'a'    => array(
+			'href'  => array(),
+			'class' => array(),
+		),
+	);
 	?>
 
 	<div class="<?php echo esc_attr( $args['class'] ); ?>">
@@ -517,14 +517,14 @@ function page_title() {
 	 */
 	$args = (array) apply_filters(
 		'go_page_title_args',
-		[
+		array(
 			'title'   => get_the_title(),
 			'wrapper' => 'h1',
-			'atts'    => [
+			'atts'    => array(
 				'class' => 'post__title m-0 text-center',
-			],
+			),
 			'custom'  => false,
-		]
+		)
 	);
 
 	/**
@@ -545,7 +545,7 @@ function page_title() {
 
 	}
 
-	$args['atts'] = empty( $args['atts'] ) ? [] : (array) $args['atts'];
+	$args['atts'] = empty( $args['atts'] ) ? array() : (array) $args['atts'];
 
 	foreach ( $args['atts'] as $key => $value ) {
 
@@ -568,7 +568,7 @@ function page_title() {
 
 	foreach ( array_keys( $args['atts'] ) as $index => $attribute ) {
 
-		$args['atts'][ $attribute ] = [];
+		$args['atts'][ $attribute ] = array();
 
 	}
 
@@ -577,9 +577,9 @@ function page_title() {
 		is_customize_preview() ? ( get_theme_mod( 'page_titles', true ) ? '' : 'display-none' ) : '',
 		wp_kses(
 			$html,
-			[
+			array(
 				$args['wrapper'] => $args['atts'],
-			]
+			)
 		)
 	);
 
@@ -638,13 +638,13 @@ function has_social_icons( $social_icons = null ) {
  *
  * @return void
  */
-function social_icons( $args = [] ) {
+function social_icons( $args = array() ) {
 	$args = wp_parse_args(
 		$args,
-		[
+		array(
 			'class'    => 'social-icons',
 			'li_class' => 'display-inline-block social-icon-%s',
-		]
+		)
 	);
 
 	$social_icons     = \Go\Core\get_social_icons();
@@ -687,7 +687,7 @@ function social_icons( $args = [] ) {
  * }
  * @return void
  */
-function display_site_branding( $args = [] ) {
+function display_site_branding( $args = array() ) {
 	echo '<div class="header__titles lg:flex items-center" itemscope itemtype="http://schema.org/Organization">';
 		site_branding( $args );
 	echo '</div>';
@@ -700,12 +700,12 @@ function display_site_branding( $args = [] ) {
  *
  * @return void
  */
-function site_branding( $args = [] ) {
+function site_branding( $args = array() ) {
 	$args = wp_parse_args(
 		$args,
-		[
+		array(
 			'description' => true,
-		]
+		)
 	);
 
 	if ( function_exists( 'the_custom_logo' ) && has_custom_logo() ) {
@@ -776,14 +776,14 @@ function load_inline_svg( $filename ) {
 	ob_start();
 
 	locate_template(
-		[
+		array(
 			sprintf(
 				'dist/images/design-styles/%1$s/%2$s',
 				sanitize_title( $design_style['label'] ),
 				$filename
 			),
 			"dist/images/{$filename}",
-		],
+		),
 		true,
 		false
 	);
@@ -792,28 +792,28 @@ function load_inline_svg( $filename ) {
 		ob_get_clean(),
 		array_merge(
 			wp_kses_allowed_html( 'post' ),
-			[
-				'svg'  => [
+			array(
+				'svg'  => array(
 					'role'    => true,
 					'width'   => true,
 					'height'  => true,
 					'fill'    => true,
 					'xmlns'   => true,
 					'viewbox' => true,
-				],
-				'path' => [
+				),
+				'path' => array(
 					'd'              => true,
 					'fill'           => true,
 					'fill-rule'      => true,
 					'stroke'         => true,
 					'stroke-width'   => true,
 					'stroke-linecap' => true,
-				],
-				'g'    => [
+				),
+				'g'    => array(
 					'd'    => true,
 					'fill' => true,
-				],
-			]
+				),
+			)
 		)
 	);
 

--- a/includes/tgm.php
+++ b/includes/tgm.php
@@ -30,13 +30,13 @@ function setup() {
  * @return void
  */
 function register_required_plugins() {
-	$plugins = [
-		[
+	$plugins = array(
+		array(
 			'name'     => 'CoBlocks',
 			'slug'     => 'coblocks',
 			'required' => false,
-		],
-	];
+		),
+	);
 
 	/**
 	 * Filters the list of plugin depedencies.
@@ -47,7 +47,7 @@ function register_required_plugins() {
 	 */
 	$plugins = apply_filters( 'go_plugin_dependencies', $plugins );
 
-	$config = [
+	$config = array(
 		'id'           => 'go',              // Unique ID for hashing notices for multiple instances of TGMPA.
 		'menu'         => 'tgmpa-install-plugins', // Menu slug.
 		'has_notices'  => true,                    // Show admin notices or not.
@@ -55,7 +55,7 @@ function register_required_plugins() {
 		'dismiss_msg'  => '',                      // If 'dismissable' is false, this message will be output at top of nag.
 		'is_automatic' => true,                    // Automatically activate plugins after installation or not.
 		'message'      => '',                      // Message to output right before the plugins table.
-	];
+	);
 
 	tgmpa( $plugins, $config );
 }

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -208,24 +208,24 @@ function empty_cart_message() {
 			$icon,
 			array_merge(
 				wp_kses_allowed_html( 'post' ),
-				[
-					'svg'  => [
+				array(
+					'svg'  => array(
 						'width'   => true,
 						'role'    => true,
 						'height'  => true,
 						'fill'    => true,
 						'xmlns'   => true,
 						'viewbox' => true,
-					],
-					'path' => [
+					),
+					'path' => array(
 						'd'    => true,
 						'fill' => true,
-					],
-					'g'    => [
+					),
+					'g'    => array(
 						'd'    => true,
 						'fill' => true,
-					],
-				]
+					),
+				)
 			)
 		),
 		esc_html( apply_filters( 'wc_empty_cart_message', __( 'Your cart is currently empty.', 'go' ) ) )
@@ -296,10 +296,10 @@ function single_product_header() {
 	<div class="product-navigation-wrapper">
 		<?php
 			woocommerce_breadcrumb(
-				[
+				array(
 					'delimiter' => '<span class="sep">&#47;</span>',
 					'home'      => woocommerce_page_title( false ),
-				]
+				)
 			);
 			single_product_pagination();
 			single_product_back_to_shop();
@@ -324,10 +324,10 @@ function single_product_pagination() {
 	$arrow_right = ob_get_clean();
 
 	the_post_navigation(
-		[
+		array(
 			'prev_text' => '<span class="screen-reader-text">' . esc_html__( 'Previous Post: ', 'go' ) . ' %title</span>' . $arrow_left . '<span class="nav-title">' . esc_html__( 'Previous', 'go' ) . '</span>',
 			'next_text' => '<span class="screen-reader-text">' . esc_html__( 'Next Post:', 'go' ) . ' %title</span><span class="nav-title">' . esc_html__( 'Next', 'go' ) . '</span>' . $arrow_right,
-		]
+		)
 	);
 
 }

--- a/partials/content-none.php
+++ b/partials/content-none.php
@@ -19,11 +19,11 @@ Go\page_title();
 				'<p>' . wp_kses(
 					/* translators: 1: link to WP admin new post page. */
 					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'go' ),
-					[
-						'a' => [
-							'href' => [],
-						],
-					]
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
 				) . '</p>',
 				esc_url( admin_url( 'post-new.php' ) )
 			);

--- a/partials/content.php
+++ b/partials/content.php
@@ -40,10 +40,10 @@
 				the_content();
 			}
 			wp_link_pages(
-				[
+				array(
 					'before' => '<nav class="post-nav-links" aria-label="' . esc_attr__( 'Page', 'go' ) . '"><span class="label">' . __( 'Pages:', 'go' ) . '</span>',
 					'after'  => '</nav>',
-				]
+				)
 			);
 			?>
 		</div>

--- a/partials/footers/footer-1.php
+++ b/partials/footers/footer-1.php
@@ -12,23 +12,23 @@ $has_background = Go\has_footer_background();
 
 	<div class="site-footer__inner max-w-wide m-auto text-center">
 
-		<?php Go\social_icons( [ 'class' => 'social-icons list-reset' ] ); ?>
+		<?php Go\social_icons( array( 'class' => 'social-icons list-reset' ) ); ?>
 
 		<?php if ( has_nav_menu( 'footer-1' ) || is_customize_preview() ) : ?>
 			<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'go' ); ?>">
 				<?php
 					wp_nav_menu(
-						[
+						array(
 							'theme_location' => 'footer-1',
 							'menu_class'     => 'footer-menu footer-menu--1 list-reset',
 							'depth'          => 1,
-						]
+						)
 					);
 				?>
 			</nav>
 		<?php endif; ?>
 
-		<?php Go\copyright( [ 'class' => 'site-info text-sm mb-0' ] ); ?>
+		<?php Go\copyright( array( 'class' => 'site-info text-sm mb-0' ) ); ?>
 
 	</div>
 

--- a/partials/footers/footer-2.php
+++ b/partials/footers/footer-2.php
@@ -16,19 +16,19 @@ $has_background = Go\has_footer_background();
 			<nav class="footer-navigation text-sm" aria-label="<?php esc_attr_e( 'Footer Menu', 'go' ); ?>">
 				<?php
 					wp_nav_menu(
-						[
+						array(
 							'theme_location' => 'footer-1',
 							'menu_class'     => 'footer-menu footer-menu--1 list-reset',
 							'depth'          => 1,
-						]
+						)
 					);
 				?>
 			</nav>
 		<?php endif; ?>
 
-		<?php Go\social_icons( [ 'class' => 'social-icons list-reset' ] ); ?>
+		<?php Go\social_icons( array( 'class' => 'social-icons list-reset' ) ); ?>
 
-		<?php Go\copyright( [ 'class' => 'site-info text-xs mb-0 lg:w-full' ] ); ?>
+		<?php Go\copyright( array( 'class' => 'site-info text-xs mb-0 lg:w-full' ) ); ?>
 
 	</div>
 

--- a/partials/footers/footer-3.php
+++ b/partials/footers/footer-3.php
@@ -15,18 +15,18 @@ $has_background   = Go\has_footer_background();
 
 		<div class="flex flex-wrap lg:justify-between lg:flex-nowrap">
 
-			<?php Go\display_site_branding( [ 'description' => false ] ); ?>
+			<?php Go\display_site_branding( array( 'description' => false ) ); ?>
 
 			<?php if ( has_nav_menu( 'footer-1' ) || is_customize_preview() ) : ?>
 				<nav class="footer-navigation footer-navigation--1 text-sm" aria-label="<?php esc_attr_e( 'Primary Footer Menu', 'go' ); ?>">
 					<span class="footer-navigation__title"><?php echo esc_html( wp_get_nav_menu_name( 'footer-1' ) ); ?></span>
 					<?php
 						wp_nav_menu(
-							[
+							array(
 								'theme_location' => 'footer-1',
 								'menu_class'     => 'footer-menu list-reset',
 								'depth'          => 1,
-							]
+							)
 						);
 					?>
 				</nav>
@@ -37,11 +37,11 @@ $has_background   = Go\has_footer_background();
 					<span class="footer-navigation__title"><?php echo esc_html( wp_get_nav_menu_name( 'footer-2' ) ); ?></span>
 					<?php
 						wp_nav_menu(
-							[
+							array(
 								'theme_location' => 'footer-2',
 								'menu_class'     => 'footer-menu list-reset',
 								'depth'          => 1,
-							]
+							)
 						);
 					?>
 				</nav>
@@ -52,11 +52,11 @@ $has_background   = Go\has_footer_background();
 					<span class="footer-navigation__title"><?php echo esc_html( wp_get_nav_menu_name( 'footer-3' ) ); ?></span>
 					<?php
 						wp_nav_menu(
-							[
+							array(
 								'theme_location' => 'footer-3',
 								'menu_class'     => 'footer-menu list-reset',
 								'depth'          => 1,
-							]
+							)
 						);
 					?>
 				</nav>
@@ -65,8 +65,8 @@ $has_background   = Go\has_footer_background();
 
 		<?php if ( $has_social_icons ) : ?>
 			<div class="site-footer__row flex flex-column lg:flex-row justify-between items-center">
-				<?php Go\copyright( [ 'class' => 'site-info text-sm mb-0' ] ); ?>
-				<?php Go\social_icons( [ 'class' => 'social-icons list-reset m-0' ] ); ?>
+				<?php Go\copyright( array( 'class' => 'site-info text-sm mb-0' ) ); ?>
+				<?php Go\social_icons( array( 'class' => 'social-icons list-reset m-0' ) ); ?>
 			</div>
 		<?php endif; ?>
 

--- a/partials/footers/footer-4.php
+++ b/partials/footers/footer-4.php
@@ -15,7 +15,7 @@ $has_background   = Go\has_footer_background();
 
 		<div class="flex flex-wrap lg:justify-start lg:flex-nowrap">
 
-			<?php Go\display_site_branding( [ 'description' => false ] ); ?>
+			<?php Go\display_site_branding( array( 'description' => false ) ); ?>
 
 			<?php if ( has_nav_menu( 'footer-1' ) || is_customize_preview() ) : ?>
 				<nav class="footer-navigation footer-navigation--1 text-sm" aria-label="<?php esc_attr_e( 'Primary Footer Menu', 'go' ); ?>">
@@ -23,11 +23,11 @@ $has_background   = Go\has_footer_background();
 
 					<?php
 						wp_nav_menu(
-							[
+							array(
 								'theme_location' => 'footer-1',
 								'menu_class'     => 'footer-menu footer-menu--1 list-reset',
 								'depth'          => 1,
-							]
+							)
 						);
 					?>
 				</nav>
@@ -39,11 +39,11 @@ $has_background   = Go\has_footer_background();
 
 					<?php
 						wp_nav_menu(
-							[
+							array(
 								'theme_location' => 'footer-2',
 								'menu_class'     => 'footer-menu footer-menu--2 list-reset',
 								'depth'          => 1,
-							]
+							)
 						);
 					?>
 				</nav>
@@ -55,11 +55,11 @@ $has_background   = Go\has_footer_background();
 
 					<?php
 						wp_nav_menu(
-							[
+							array(
 								'theme_location' => 'footer-3',
 								'menu_class'     => 'footer-menu footer-menu--3 list-reset',
 								'depth'          => 1,
-							]
+							)
 						);
 					?>
 				</nav>
@@ -68,8 +68,8 @@ $has_background   = Go\has_footer_background();
 
 		<?php if ( $has_social_icons ) : ?>
 			<div class="site-footer__row flex flex-column lg:flex-row justify-between lg:items-center">
-				<?php Go\copyright( [ 'class' => 'site-info text-sm mb-0' ] ); ?>
-				<?php Go\social_icons( [ 'class' => 'social-icons list-reset' ] ); ?>
+				<?php Go\copyright( array( 'class' => 'site-info text-sm mb-0' ) ); ?>
+				<?php Go\social_icons( array( 'class' => 'social-icons list-reset' ) ); ?>
 			</div>
 		<?php endif; ?>
 

--- a/partials/pagination.php
+++ b/partials/pagination.php
@@ -8,7 +8,7 @@
  */
 
 $posts_pagination = get_the_posts_pagination(
-	[
+	array(
 		'mid_size'  => 2,
 		/**
 		 * Translators:
@@ -25,7 +25,7 @@ $posts_pagination = get_the_posts_pagination(
 			__( 'Older <span class="nav-short">Posts</span>', 'go' ),
 			'&rarr;'
 		),
-	]
+	)
 );
 
 // If we're only showing one of the next or previous links, add a class indicating so.


### PR DESCRIPTION
As per WordPress Coding Standards, we should not be using shorthand array syntax (`[]`).
https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#declaring-arrays