### PR TITLE
Fix header regression for absolute positioning

### DIFF
--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -131,8 +131,8 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		svn co --ignore-externals --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --ignore-externals --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/header.php
+++ b/header.php
@@ -26,7 +26,7 @@
 
 		<a class="skip-link screen-reader-text" href="#site-content"><?php esc_html_e( 'Skip to content', 'go' ); ?></a>
 
-		<header id="site-header" class="header relative <?php echo esc_attr( Go\has_header_background() ); ?>" role="banner" itemscope itemtype="http://schema.org/WPHeader">
+		<header id="site-header" class="site-header header relative <?php echo esc_attr( Go\has_header_background() ); ?>" role="banner" itemscope itemtype="http://schema.org/WPHeader">
 
 			<div class="header__inner flex items-center justify-between h-inherit w-full relative">
 


### PR DESCRIPTION
This PR adds back the `site-header` class, which resolves the visual header regression reported by @fjarrett. 

Before: 
<img width="1404" alt="Screen Shot 2019-11-22 at 2 53 10 PM" src="https://user-images.githubusercontent.com/1813435/69456105-e1bf6280-0d37-11ea-99e4-40161be7c800.png">

After: 
<img width="1400" alt="Screen Shot 2019-11-22 at 2 53 27 PM" src="https://user-images.githubusercontent.com/1813435/69456120-eab03400-0d37-11ea-9d8f-a89933ff6b01.png">
