### PR TITLE
Add jQuery as dependency of frontend.js

### DIFF
--- a/.dev/assets/shared/js/frontend/components/woo-menu-cart.js
+++ b/.dev/assets/shared/js/frontend/components/woo-menu-cart.js
@@ -5,7 +5,7 @@ let sideNavClose = document.getElementById( 'site-close-handle' );
 
 const wooMenuCart = () => {
 	if (
-		! menuObject ||
+		null === menuObject ||
 		null === siteOverlay ||
 		null === sideNavClose
 	) {

--- a/.dev/assets/shared/js/frontend/components/woo-menu-cart.js
+++ b/.dev/assets/shared/js/frontend/components/woo-menu-cart.js
@@ -1,11 +1,11 @@
-let menuObject   = jQuery( 'button.header__cart-toggle' );
+let menuObject   = document.getElementById( 'header__cart-toggle' );
 let siteOverlay  = document.getElementById( 'site-overlay' );
 let sideNav      = document.getElementById( 'site-nav--cart' );
 let sideNavClose = document.getElementById( 'site-close-handle' );
 
 const wooMenuCart = () => {
 	if (
-		! menuObject.length ||
+		! menuObject ||
 		null === siteOverlay ||
 		null === sideNavClose
 	) {
@@ -14,7 +14,7 @@ const wooMenuCart = () => {
 
 	document.body.classList.add( 'has-woo-cart-slideout' );
 
-	menuObject.on( 'click', function( event ) {
+	menuObject.addEventListener( 'click',  function( event ) {
 		event.preventDefault();
 		toggleSideNavVisibility();
 	} );

--- a/includes/core.php
+++ b/includes/core.php
@@ -318,7 +318,7 @@ function scripts() {
 	wp_enqueue_script(
 		'go-frontend',
 		get_theme_file_uri( "dist/js/frontend{$suffix}.js" ),
-		array(),
+		array( 'jquery' ),
 		GO_VERSION,
 		true
 	);

--- a/includes/core.php
+++ b/includes/core.php
@@ -318,7 +318,7 @@ function scripts() {
 	wp_enqueue_script(
 		'go-frontend',
 		get_theme_file_uri( "dist/js/frontend{$suffix}.js" ),
-		array( 'jquery' ),
+		array(),
 		GO_VERSION,
 		true
 	);

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -84,6 +84,12 @@ function should_show_woo_cart_item() {
  */
 function should_use_woo_slideout_cart() {
 
+	if ( is_cart() ) {
+
+		return false;
+
+	}
+
 	/**
 	 * Filter whether to use the WooCommerce slideout cart.
 	 * Default: `true`
@@ -164,9 +170,9 @@ function woocommerce_cart_link() {
 	$element_wrap = should_use_woo_slideout_cart() ? 'button' : 'a';
 
 	printf(
-		'<%1$s id="header__cart-toggle" href="%2$s" class="header__cart-toggle" alt="%3$s">%4$s</%1$s>',
+		'<%1$s id="header__cart-toggle" %2$s class="header__cart-toggle" alt="%3$s">%4$s</%1$s>',
 		esc_html( $element_wrap ),
-		esc_url( $cart_url ),
+		( 'a' === $element_wrap ) ? 'href="' . esc_url( $cart_url ) . '"' : '',
 		esc_attr( $cart_alt_text ),
 		$cart_text // @codingStandardsIgnoreLine
 	);

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -164,7 +164,7 @@ function woocommerce_cart_link() {
 	$element_wrap = should_use_woo_slideout_cart() ? 'button' : 'a';
 
 	printf(
-		'<%1$s href="%2$s" class="header__cart-toggle" alt="%3$s">%4$s</%1$s>',
+		'<%1$s id="header__cart-toggle" href="%2$s" class="header__cart-toggle" alt="%3$s">%4$s</%1$s>',
 		esc_html( $element_wrap ),
 		esc_url( $cart_url ),
 		esc_attr( $cart_alt_text ),


### PR DESCRIPTION
Resolves the js error generated on non-store templates
https://wpnux.test-godaddy.com/v2/?template=studio&lang=en_US

- Removes `href` attribute from the cart slide out `button` element.
- Disable the WooCommerce slide out cart when on the actual cart page.