### PR TITLE
Update typography.css

### DIFF
--- a/.dev/assets/shared/css/elements/typography.css
+++ b/.dev/assets/shared/css/elements/typography.css
@@ -12,7 +12,6 @@ body {
 }
 
 p {
-	font-family: var(--theme-body--font);
 	font-size: var(--theme-body--font-size);
 	line-height: var(--theme-body--leading);
 }


### PR DESCRIPTION
Overly specific CSS declarations make it harder for plugins to customize the theme. In this instance `p` is already inheriting the `font-family` from `body`.