### PR TITLE
Fix PHPUnit tests

### DIFF
--- a/.dev/tests/php/bootstrap.php
+++ b/.dev/tests/php/bootstrap.php
@@ -76,6 +76,29 @@ function _register_theme() {
 }
 tests_add_filter( 'muplugins_loaded', '_register_theme' );
 
+/**
+ * Install WooCommerce
+ */
+tests_add_filter( 'setup_theme', function() {
+	include '/tmp/wordpress/wp-content/plugins/woocommerce/woocommerce.php';
+	// Clean existing install first.
+	define( 'WP_UNINSTALL_PLUGIN', true );
+	define( 'WC_REMOVE_ALL_DATA', true );
+	include '/tmp/wordpress/wp-content/plugins/woocommerce/uninstall.php';
+	WC_Install::install();
+	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374
+	if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
+		$GLOBALS['wp_roles']->reinit();
+	} else {
+		$GLOBALS['wp_roles'] = null; // WPCS: override ok.
+		wp_roles();
+	}
+	echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
+	// global $wp_rewrite;
+	// $wp_rewrite->set_permalink_structure('/%postname%/');
+	// $wp_rewrite->flush_rules();
+} );
+
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';

--- a/.dev/tests/php/bootstrap.php
+++ b/.dev/tests/php/bootstrap.php
@@ -94,9 +94,6 @@ tests_add_filter( 'setup_theme', function() {
 		wp_roles();
 	}
 	echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
-	// global $wp_rewrite;
-	// $wp_rewrite->set_permalink_structure('/%postname%/');
-	// $wp_rewrite->flush_rules();
 } );
 
 

--- a/.dev/tests/php/test-template-tags.php
+++ b/.dev/tests/php/test-template-tags.php
@@ -1058,31 +1058,6 @@ class Test_Template_Tags extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test WooCommerce content wraper classes are added when WooCommerce is prsent
-	 */
-	public function test_content_wrapper_class_woo_cart() {
-
-		if ( ! class_exists( 'WooCommerce' ) ) {
-
-			include WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
-
-		}
-
-		// Force WooCommerce is_cart() true
-		define( 'WOOCOMMERCE_CART', true );
-
-		// Force WooCommerce is_checkout() true
-		apply_filters( 'woocommerce_is_checkout', '__return_true' );
-
-		ob_start();
-		Go\content_wrapper_class();
-		$content_wrapper_class = ob_get_clean();
-
-		$this->assertEquals( 'max-w-wide w-full m-auto px', trim( $content_wrapper_class ) );
-
-	}
-
-	/**
 	 * Test that has_social_icons returns true when social icons are set
 	 */
 	public function test_has_social_icons() {

--- a/.dev/tests/php/test-template-tags.php
+++ b/.dev/tests/php/test-template-tags.php
@@ -1014,6 +1014,39 @@ class Test_Template_Tags extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the page does not show up on the front page of the site
+	 */
+	public function test_page_title_front_page() {
+
+		$front_page_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Front Page',
+				'post_content' => 'This is the front page of my site.',
+			]
+		);
+
+		update_option( 'page_on_front', $front_page_id );
+		update_option( 'show_on_front', 'page' );
+
+		global $post;
+		global $wp_query;
+
+		$post = get_post( $front_page_id );
+
+		$wp_query                 = new WP_Query( [ 'page_id' => $front_page_id ] );
+		$wp_query->queried_object = $post;
+		$wp_query->is_page        = true;
+		$wp_query->is_single      = true;
+
+		ob_start();
+		Go\page_title();
+		$page_title = ob_get_clean();
+
+		$this->assertEmpty( $page_title );
+
+	}
+
+	/**
 	 * Test the page title renders correctly
 	 */
 	public function test_page_title() {

--- a/.dev/tests/php/test-template-tags.php
+++ b/.dev/tests/php/test-template-tags.php
@@ -1044,6 +1044,8 @@ class Test_Template_Tags extends WP_UnitTestCase {
 
 		$this->assertEmpty( $page_title );
 
+		wp_reset_query();
+
 	}
 
 	/**

--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -398,7 +398,7 @@ class Test_WooCommerce extends WP_UnitTestCase {
 	 */
 	function test_woocommerce_cart_link() {
 
-		$this->expectOutputRegex( '/<button href="http:\/\/example.org" class="header__cart-toggle" alt="View cart"><svg role="img" viewBox="0 0 24 24" height="24" width="24" xmlns="http:\/\/www.w3.org\/2000\/svg">/' );
+		$this->expectOutputRegex( '/<button id="header__cart-toggle" class="header__cart-toggle" alt="View cart"><svg role="img" viewBox="0 0 24 24" height="24" width="24" xmlns="http:\/\/www.w3.org\/2000\/svg">/' );
 
 		$this->initialize_woo_session();
 
@@ -445,11 +445,13 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		$this->initialize_woo_session();
 
+		add_filter( 'go_wc_use_slideout_cart', '__return_false' );
+
 		add_filter( 'go_menu_cart_url', function() {
 			return 'https://www.google.com';
 		} );
 
-		$this->expectOutputRegex( '/<button href="https:\/\/www.google.com" class="header__cart-toggle" alt="View cart"><svg role="img" viewBox="0 0 24 24" height="24" width="24" xmlns="http:\/\/www.w3.org\/2000\/svg">/' );
+		$this->expectOutputRegex( '/<a id="header__cart-toggle" href="https:\/\/www.google.com" class="header__cart-toggle" alt="View cart"><svg role="img" viewBox="0 0 24 24" height="24" width="24" xmlns="http:\/\/www.w3.org\/2000\/svg">/' );
 
 		Go\WooCommerce\woocommerce_cart_link();
 
@@ -462,11 +464,13 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		$this->initialize_woo_session();
 
+		add_filter( 'go_wc_use_slideout_cart', '__return_false' );
+
 		add_filter( 'go_menu_cart_alt', function() {
 			return 'Alternate Text';
 		} );
 
-		$this->expectOutputRegex( '/<button href="http:\/\/example.org" class="header__cart-toggle" alt="Alternate Text">/' );
+		$this->expectOutputRegex( '/<a id="header__cart-toggle" href="http:\/\/example.org" class="header__cart-toggle" alt="Alternate Text">/' );
 
 		Go\WooCommerce\woocommerce_cart_link();
 
@@ -479,11 +483,13 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		$this->initialize_woo_session();
 
+		add_filter( 'go_wc_use_slideout_cart', '__return_false' );
+
 		add_filter( 'go_menu_cart_text', function() {
 			return 'Custom Cart Text';
 		} );
 
-		$this->expectOutputRegex( '/<button href="http:\/\/example.org" class="header__cart-toggle" alt="View cart">Custom Cart Text<\/button>/' );
+		$this->expectOutputRegex( '/<a id="header__cart-toggle" href="http:\/\/example.org" class="header__cart-toggle" alt="View cart">Custom Cart Text<\/a>/' );
 
 		Go\WooCommerce\woocommerce_cart_link();
 
@@ -500,7 +506,7 @@ class Test_WooCommerce extends WP_UnitTestCase {
 			return '';
 		} );
 
-		$this->expectOutputRegex( '/<button href="http:\/\/example.org" class="header__cart-toggle" alt="View cart"><svg role="img" viewBox="0 0 24 24" height="24" width="24" xmlns="http:\/\/www.w3.org\/2000\/svg">/' );
+		$this->expectOutputRegex( '/<button id="header__cart-toggle" class="header__cart-toggle" alt="View cart"><svg role="img" viewBox="0 0 24 24" height="24" width="24" xmlns="http:\/\/www.w3.org\/2000\/svg">/' );
 
 		Go\WooCommerce\woocommerce_cart_link();
 

--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -546,9 +546,9 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		$product_id = $this->create_simple_product();
 
-		$this->woo_cart->add_to_cart( $product_id, 3 );
+		$this->woo->cart->add_to_cart( $product_id, 3 );
 
-		$this->woo_cart->calculate_totals();
+		$this->woo->cart->calculate_totals();
 
 		$expected_fragments = [
 			'.class'                 => 'Text',

--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -598,7 +598,6 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 	/**
 	 * Test that the Cart link is visible when the cart contents count is greater than zero
-	 * @group Test
 	 */
 	function test_disable_cart_cart_contents_greater_than_zero() {
 

--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -6,8 +6,6 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 	private $woo_cart;
 
-	private $shop_page_id;
-
 	function setUp() {
 
 		parent::setUp();
@@ -64,7 +62,7 @@ class Test_WooCommerce extends WP_UnitTestCase {
 			$GLOBALS['wp_roles'] = null;
 			wp_roles();
 
-			$this->shop_page_id = $this->factory->post->create(
+			$shop_page_id = $this->factory->post->create(
 				[
 					'post_title'   => 'Shop Page',
 					'post_type'    => 'page',
@@ -72,7 +70,7 @@ class Test_WooCommerce extends WP_UnitTestCase {
 				]
 			);
 
-			update_option( 'woocommerce_shop_page_id', $this->shop_page_id );
+			update_option( 'woocommerce_shop_page_id', $shop_page_id );
 
 		}
 
@@ -956,6 +954,34 @@ class Test_WooCommerce extends WP_UnitTestCase {
 		$this->initialize_woo_session();
 
 		$this->assertEquals( '<a class="reset_variations" href="#">Reset Selections</a>', Go\WooCommerce\reset_variations_link() );
+
+	}
+
+	/**
+	 * Test WooCommerce content wraper classes are added when WooCommerce is present
+	 *
+	 * Note: From test-template-tags.php. Defining WOOCOMMERCE_CART forces other tests to fail.
+	 *       This should always be run last.
+	 */
+	public function test_content_wrapper_class_woo_cart() {
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
+
+			include WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+
+		}
+
+		// Force WooCommerce is_cart() true
+		define( 'WOOCOMMERCE_CART', true );
+
+		// Force WooCommerce is_checkout() true
+		apply_filters( 'woocommerce_is_checkout', '__return_true' );
+
+		ob_start();
+		Go\content_wrapper_class();
+		$content_wrapper_class = ob_get_clean();
+
+		$this->assertEquals( 'max-w-wide w-full m-auto px', trim( $content_wrapper_class ) );
 
 	}
 }

--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -546,9 +546,9 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		$product_id = $this->create_simple_product();
 
-		$this->woo->cart->add_to_cart( $product_id, 3 );
+		$this->woo_cart->add_to_cart( $product_id, 3 );
 
-		$this->woo->cart->calculate_totals();
+		$this->woo_cart->calculate_totals();
 
 		$expected_fragments = [
 			'.class'                 => 'Text',
@@ -982,6 +982,16 @@ class Test_WooCommerce extends WP_UnitTestCase {
 		$content_wrapper_class = ob_get_clean();
 
 		$this->assertEquals( 'max-w-wide w-full m-auto px', trim( $content_wrapper_class ) );
+
+	}
+
+	/**
+	 * Test that the Cart is false on the shop page
+	 * Note: Should run after WOOCOMMERCE_CART is defined in the test above
+	 */
+	function test_should_use_woo_slideout_cart_cart_page() {
+
+		$this->assertFalse( Go\WooCommerce\should_use_woo_slideout_cart() );
 
 	}
 }

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -170,9 +170,9 @@ function woocommerce_cart_link() {
 	$element_wrap = should_use_woo_slideout_cart() ? 'button' : 'a';
 
 	printf(
-		'<%1$s id="header__cart-toggle" %2$s class="header__cart-toggle" alt="%3$s">%4$s</%1$s>',
+		'<%1$s id="header__cart-toggle"%2$sclass="header__cart-toggle" alt="%3$s">%4$s</%1$s>',
 		esc_html( $element_wrap ),
-		( 'a' === $element_wrap ) ? 'href="' . esc_url( $cart_url ) . '"' : '',
+		( 'a' === $element_wrap ) ? ' href="' . esc_url( $cart_url ) . '" ' : ' ',
 		esc_attr( $cart_alt_text ),
 		$cart_text // @codingStandardsIgnoreLine
 	);

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -16,11 +16,13 @@ use function Go\load_inline_svg;
  */
 function setup() {
 
+	// @codeCoverageIgnoreStart
 	if ( ! class_exists( 'WooCommerce' ) ) {
 
 		return;
 
 	}
+	// @codeCoverageIgnoreEnd
 
 	$n = function( $function ) {
 		return __NAMESPACE__ . "\\$function";


### PR DESCRIPTION
- Hook into `setup_theme ` and Install WooCommerce before the tests run.
- Tweak spacing in WooCommerce menu cart toggle attributes.
- Update unit tests to account for WooCommerce menu cart toggle `button` element no longer containing an `href` attribute.
- Refactor a number of tests inside of  `test-woocommerce.php`.
- Introduced a new test to test for front page titles being hidden.