### PR TITLE
Prevent site header from overlapping the mobile menu

### DIFF
--- a/.dev/assets/shared/css/header/header.css
+++ b/.dev/assets/shared/css/header/header.css
@@ -1,6 +1,7 @@
 /*! Header */
 .header {
 	background-color: hsl(var(--theme-header--bg));
+	z-index: 2;
 
 	& .u-informational {
 		display: inline-block;


### PR DESCRIPTION
Resolves #448 

Set z-index on .header to prevent overlaps with the menu