### PR TITLE
Fix Welcoming design style page with featured image

### DIFF
--- a/.dev/assets/shared/css/layout/featured-image.css
+++ b/.dev/assets/shared/css/layout/featured-image.css
@@ -4,7 +4,7 @@
 	overflow: hidden;
 	padding-bottom: calc(var(--theme-featured-img--height, 35%) * 1.5);
 	position: relative;
-	z-index: -1;
+	z-index: 0;
 
 	@media (--medium) {
 		padding-bottom: var(--theme-featured-img--height, 35%);
@@ -56,7 +56,7 @@
 	}
 }
 
-.has-featured-image:not(.menu-is-open) {
+.has-featured-image:not(.is-style-welcoming):not(.menu-is-open) {
 
 	& .site-title,
 	& .site-description,


### PR DESCRIPTION
Tweak CSS to ensure featured images display correctly on pages with one set (`z-index`). Additionally, fix the welcoming design style menu color on pages where featured images are set.

![image](https://user-images.githubusercontent.com/5321364/75487225-0735bb00-597c-11ea-96ad-7510eb2e4423.png)
