### PR TITLE
Bump tested up to version to 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 		<img src="https://img.shields.io/circleci/build/github/godaddy-wordpress/go/master?label=&logo=circleci&style=flat-square" alt="CircleCI Build">
 	</a>
 	<a href="https://wordpress.org/" target="_blank">
-		<img src="https://img.shields.io/static/v1?label=&message=5.0+-+5.3&color=blue&style=flat-square&logo=wordpress&logoColor=white" alt="WordPress Versions">
+		<img src="https://img.shields.io/static/v1?label=&message=5.0+-+5.4&color=blue&style=flat-square&logo=wordpress&logoColor=white" alt="WordPress Versions">
 	</a>
 	<a href="https://www.php.net/" target="_blank">
 		<img src="https://img.shields.io/static/v1?label=&message=5.6+-+7.3&color=777bb4&style=flat-square&logo=php&logoColor=white" alt="PHP Versions">

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: godaddy, richtabor, eherman24, jrtashjian
 Tags: one-column, custom-colors, custom-logo, custom-menu, editor-style, theme-options, threaded-comments, translation-ready, block-styles, wide-blocks
 Requires at least: 5.0
-Tested up to: 5.2
+Tested up to: 5.4
 Requires PHP: 5.6.0
 Stable tag: 1.2.4
 License: GPL-2.0-only


### PR DESCRIPTION
Prepare readme files for WordPress 5.4 release slated for March 31, 2020.