### PR TITLE
Improve npm run watch with flags

### DIFF
--- a/.dev/config/webpack.dev.js
+++ b/.dev/config/webpack.dev.js
@@ -46,7 +46,7 @@ if ( 'development' === process.env.NODE_ENV ) {
 
 	}
 
-	// Generate the RTL files when running `npm run watch` and a --rtl flag is set
+	// Generate the RTL files when running `npm run start` and a --rtl flag is set
 	if ( flags.includes( 'rtl' ) ) {
 		module.exports.plugins.push(
 			new RtlCssPlugin( { filename: 'css/[name]-rtl.css' } ),
@@ -62,7 +62,7 @@ if ( 'development' === process.env.NODE_ENV ) {
 		}
 	}
 
-	// Minify both the standard .css file and the -rtl.css files when running `npm run watch` and a --min flag is set
+	// Minify both the standard .css file and the -rtl.css files when running `npm run start` and a --min flag is set
 	if ( flags.includes( 'min' ) ) {
 		module.exports.plugins.push(
 			new MiniCssExtractPlugin( {

--- a/.dev/config/webpack.dev.js
+++ b/.dev/config/webpack.dev.js
@@ -25,7 +25,6 @@ module.exports = merge( common, {
 				reload: false,
 			}
 		),
-		new RtlCssPlugin( { filename: 'css/[name]-rtl.css' } ),
 		new OptimizeCssAssetsPlugin( {
 			assetNameRegExp: /\.*\.css$/g,
 			cssProcessor: require( 'cssnano' ),
@@ -37,16 +36,39 @@ module.exports = merge( common, {
 	],
 } );
 
-// Minify both the standard .css file and the -rtl.css files when running `npm run watch`
 if ( 'development' === process.env.NODE_ENV ) {
-	module.exports.plugins.push(
-		new MiniCssExtractPlugin( {
-			filename: 'css/[name].min.css',
-			chunkFilename: '[id].css',
-		} ),
-		new MiniCssExtractPlugin( {
-			filename: 'css/[name]-rtl.min.css',
-			chunkFilename: '[id].css',
-		} ),
-	);
+
+	let flags = [];
+
+	if ( undefined !== process.argv[5] ) {
+
+		flags = process.argv[5].replace( '--', '' ).split( ',' );
+
+	}
+
+	// Generate the RTL files when running `npm run watch` and a --rtl flag is set
+	if ( flags.includes( 'rtl' ) ) {
+		module.exports.plugins.push(
+			new RtlCssPlugin( { filename: 'css/[name]-rtl.css' } ),
+		);
+
+		if ( flags.includes( 'min' ) ) {
+			module.exports.plugins.push(
+				new MiniCssExtractPlugin( {
+					filename: 'css/[name]-rtl.min.css',
+					chunkFilename: '[id].css',
+				} ),
+			);
+		}
+	}
+
+	// Minify both the standard .css file and the -rtl.css files when running `npm run watch` and a --min flag is set
+	if ( flags.includes( 'min' ) ) {
+		module.exports.plugins.push(
+			new MiniCssExtractPlugin( {
+				filename: 'css/[name].min.css',
+				chunkFilename: '[id].css',
+			} ),
+		);
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2845,12 +2845,6 @@
         "regenerator-runtime": "^0.10.0"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-          "dev": true
-        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -3978,6 +3972,12 @@
         }
       }
     },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "dev": true
+    },
     "core-js-compat": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
@@ -4817,6 +4817,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -6443,6 +6452,51 @@
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
+    "gettext-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-3.1.1.tgz",
+      "integrity": "sha512-vNhWcqXEtZPs5Ft1ReA34g7ByWotpcOIeJvXVy2jF3/G2U9v6W0wG4Z4hXzcU8R//jArqkgHcVCGgGqa4vxVlQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.12",
+        "readable-stream": "^3.2.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "gettext-to-messageformat": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/gettext-to-messageformat/-/gettext-to-messageformat-0.3.0.tgz",
+      "integrity": "sha512-HlEGFECqAavbOYJTo1I2qh8IqWetAenixaH/AbdIuNTY0easvzrPn+yYUHy63GEjx9pXoLx2nCJcDcE27LrB2g==",
+      "dev": true,
+      "requires": {
+        "gettext-parser": "^1.3.0"
+      },
+      "dependencies": {
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -6693,11 +6747,30 @@
         "which": "~1.3.0"
       }
     },
+    "grunt-potomo": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-potomo/-/grunt-potomo-3.5.0.tgz",
+      "integrity": "sha1-WtjG9+djrVtRg55cbTI1gGLHN5U=",
+      "dev": true,
+      "requires": {
+        "shelljs": "~0.7.5"
+      }
+    },
     "grunt-text-replace": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz",
       "integrity": "sha1-252c5Z4v5J2id+nbwZXD4Rz7FsI=",
       "dev": true
+    },
+    "grunt-wp-i18n": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/grunt-wp-i18n/-/grunt-wp-i18n-1.0.3.tgz",
+      "integrity": "sha512-CJNbEKeBeOSAPeaJ9B8iCgSwtaG63UR9/uT46a4OsIqnFhOJpeAi138JTlvjfIbnDVoBrzvdrKJe1svveLjUtA==",
+      "dev": true,
+      "requires": {
+        "grunt": "^1.0.3",
+        "node-wp-i18n": "^1.2.2"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -7743,6 +7816,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json2po": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/json2po/-/json2po-1.0.5.tgz",
+      "integrity": "sha1-rovZQ/4DhwrDPnseDvmJgxbjYXc=",
       "dev": true
     },
     "json5": {
@@ -8992,6 +9071,21 @@
         }
       }
     },
+    "node-wp-i18n": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/node-wp-i18n/-/node-wp-i18n-1.2.3.tgz",
+      "integrity": "sha512-YMzMcsjXbGYDB9vHyb289CYXAGmXhcNLbeTlOnWgPNkZd9xrovcbRd7cQyKd9BQHOjS7Nw8WCbJ7nvtR7rc0rg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.4.1",
+        "gettext-parser": "^3.1.0",
+        "glob": "^7.0.5",
+        "lodash": "^4.14.2",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "tmp": "^0.0.33"
+      }
+    },
     "node.extend": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
@@ -9741,6 +9835,29 @@
       "dev": true,
       "requires": {
         "semver-compare": "^1.0.0"
+      }
+    },
+    "po2json": {
+      "version": "1.0.0-beta-2",
+      "resolved": "https://registry.npmjs.org/po2json/-/po2json-1.0.0-beta-2.tgz",
+      "integrity": "sha512-r8+BmXPiqEsztwDo5bhbLXskiIwCtfM5IeMwhvxy2Ui1esi4yBOE7h8CIuNPvLWGzFXtjqtPUaSF1wIunCFCqw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.18.0",
+        "gettext-parser": "2.0.0",
+        "gettext-to-messageformat": "0.3.0"
+      },
+      "dependencies": {
+        "gettext-parser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-2.0.0.tgz",
+          "integrity": "sha512-FDs/7XjNw58ToQwJFO7avZZbPecSYgw8PBYhd0An+4JtZSrSzKhEvTsVV2uqdO7VziWTOGSgLGD5YRPdsCjF7Q==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.2"
+          }
+        }
       }
     },
     "portscanner": {
@@ -11815,6 +11932,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -12144,9 +12270,9 @@
       }
     },
     "rtlcss": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.4.1.tgz",
-      "integrity": "sha512-pOY30CIGvvQTW1iBfxO6Ry6/J/C4U7fcOhtF0pm5fNgwmJXOtx5gib6czFmWyp1KXN/6rbMRsTZwWlAridxBTQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.5.0.tgz",
+      "integrity": "sha512-NCVdF45w70/3CQeqVvQ84bu2HN8agNn+CDjw+RxXaiWb7mPOmEvltdd1z4qzm9kin4Jnu9ShFBIx28yvWerZ2g==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -12481,6 +12607,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "start": "composer install && npm install && npm run build",
     "build": "NODE_ENV=production webpack --config .dev/config/webpack.prod.js",
-    "postbuild": "mkdir temp && cp -a dist/* temp && NODE_ENV=development webpack --config .dev/config/webpack.dev.js && cp -a temp/* dist && rm -rf temp && .dev/deploy-scripts/tweak-css-files.sh && npm run makepot",
+    "postbuild": "rm -rf temp && mkdir temp && cp -a dist/* temp && NODE_ENV=development webpack --config .dev/config/webpack.dev.js && cp -a temp/* dist && rm -rf temp && .dev/deploy-scripts/tweak-css-files.sh && npm run makepot",
     "dev": "NODE_ENV=development webpack --config .dev/config/webpack.dev.js",
     "postdev": "mkdir temp && cp -a dist/* temp && NODE_ENV=production webpack --config .dev/config/webpack.prod.js && cp -a temp/* dist && rm -rf temp && .dev/deploy-scripts/tweak-css-files.sh",
     "watch": "NODE_ENV=development webpack --watch --config .dev/config/webpack.dev.js",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,11 @@
     "[![WordPress <%= pkg.engines.wordpress %>](https://img.shields.io/badge/wordpress-<% print(encodeURI(pkg.engines.wordpress)) %>-blue.svg)](https://wordpress.org/download/release-archive/)"
   ],
   "scripts": {
-    "start": "composer install && npm install && npm run build",
+    "setup": "composer install && npm install && npm run build",
+    "start": "NODE_ENV=development webpack --watch --config .dev/config/webpack.dev.js",
     "build": "NODE_ENV=production webpack --config .dev/config/webpack.prod.js",
     "postbuild": "rm -rf temp && mkdir temp && cp -a dist/* temp && NODE_ENV=development webpack --config .dev/config/webpack.dev.js && cp -a temp/* dist && rm -rf temp && .dev/deploy-scripts/tweak-css-files.sh && npm run makepot",
-    "dev": "NODE_ENV=development webpack --config .dev/config/webpack.dev.js",
     "postdev": "mkdir temp && cp -a dist/* temp && NODE_ENV=production webpack --config .dev/config/webpack.prod.js && cp -a temp/* dist && rm -rf temp && .dev/deploy-scripts/tweak-css-files.sh",
-    "watch": "NODE_ENV=development webpack --watch --config .dev/config/webpack.dev.js",
     "package": "rm -rf build && mkdir -p build/go && npm run build && rsync -av --exclude-from .distignore --delete . build/go && cd build && zip -r go.zip ./go",
     "version": "grunt version && git add -A .",
     "postversion": "git push && git push --tags",


### PR DESCRIPTION
`npm run watch` will now only generate standard .css files. This means that, when developing with Go, you will need `SCRIPT_DEBUG` defined and set to `true`.
`define( 'SCRIPT_DEBUG', true );`

You can watch and generate `.min.css`, `-rtl.css` and `-rtl.min.css` files by adding flags to the `npm run watch` command.

#### Generate standard CSS assets
`npm run watch`

#### Generate standard and minified CSS assets
`npm run watch  -- --min`

#### Generate standard and RTL CSS assets
`npm run watch -- --rtl`

#### Generate standard, RTL, minified and minified RTL CSS assets
`npm run watch  -- --min,rtl`

#### But why split it this way?
By splitting the watch command this way we have essentially decreased the time it takes to regenerate CSS assets by 50%, so development should be faster.

Previous watch run time: `2.7s`
Current watch run time: `1.34s`