### PR TITLE
Update copyright footer text

### DIFF
--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -995,7 +995,7 @@ class Test_Core extends WP_UnitTestCase {
 	 */
 	function testGetDefaultCopyright() {
 
-		$this->assertEquals( 'WordPress Theme by GoDaddy', Go\Core\get_default_copyright() );
+		$this->assertEquals( 'Test Blog', Go\Core\get_default_copyright() );
 
 	}
 

--- a/.dev/tests/php/test-template-tags.php
+++ b/.dev/tests/php/test-template-tags.php
@@ -845,7 +845,7 @@ class Test_Template_Tags extends WP_UnitTestCase {
 			return $args;
 		} );
 
-		$this->expectOutputRegex( '/WordPress Theme by GoDaddy/' );
+		$this->expectOutputRegex( '/Test Blog/' );
 
 		Go\footer_variation();
 
@@ -911,7 +911,7 @@ class Test_Template_Tags extends WP_UnitTestCase {
 	 */
 	public function test_copyright() {
 
-		$this->expectOutputRegex( '/WordPress Theme by GoDaddy/' );
+		$this->expectOutputRegex( '/Test Blog/' );
 
 		Go\copyright();
 

--- a/includes/core.php
+++ b/includes/core.php
@@ -1049,7 +1049,7 @@ function get_default_copyright() {
 	 * @param string $copyright The default text for copyright.
 	 */
 	/* translators: the theme author */
-	return (string) apply_filters( 'go_default_copyright', sprintf( esc_html__( 'WordPress Theme by %s', 'go' ), 'GoDaddy' ) );
+	return (string) apply_filters( 'go_default_copyright', get_bloginfo( 'name' ) );
 
 }
 

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -456,7 +456,7 @@ function copyright( $args = array() ) {
 		)
 	);
 
-	$year      = sprintf( '&copy; %s&nbsp;', esc_html( gmdate( 'Y' ) ) );
+	$year      = sprintf( '&copy; %s', esc_html( gmdate( 'Y' ) ) );
 	$copyright = get_theme_mod( 'copyright', \Go\Core\get_default_copyright() );
 
 	$html = array(


### PR DESCRIPTION
**Related:** https://themes.trac.wordpress.org/ticket/80763#comment:3

- [x] Update the default copyright footer text to the site name.
- [x] Remove non breaking space after the year in the copyright footer text.