### PR TITLE
Bump .header z-index higher

### DIFF
--- a/.dev/assets/shared/css/header/header.css
+++ b/.dev/assets/shared/css/header/header.css
@@ -1,7 +1,7 @@
 /*! Header */
 .header {
 	background-color: var(--go-header--color--background);
-	z-index: 2;
+	z-index: 99;
 
 	& .u-informational {
 		display: inline-block;


### PR DESCRIPTION
This PR bumps the `.header` element z-index to 99 to account for plugins and other things setting high z-index on blocks on the page.

**Example:**
https://wordpress.org/support/topic/top-header-menu-not-working-on-mobile-2/