### PR TITLE
Update the Canary build deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,13 +359,16 @@ jobs:
             sed -i -e "${GO_VERSION_LINE}s/$/-${GO_COMMIT_HASH}/" ./go/style.css
             zip -r /tmp/artifacts/go-canary.zip ./go
       - run:
-          name: Deploy Go theme to the staging site
-          command: |
-            scp -r /tmp/artifacts/go-canary.zip ${STAGING_SITE_SSH_CREDS}:html/wp-content/
-            ssh ${STAGING_SITE_SSH_CREDS} 'cd html/wp-content && wp theme install go-canary.zip --force --activate --skip-themes --skip-plugins && rm -rf go-canary.zip'
-      - deploy:
           name: Create a canary release on GitHub
           command: ghr -t ${GH_ACCESS_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "canary" -b "Latest build of the master branch. This bleeding edge version is for testing purposes only and should not be used in production." -delete -prerelease -replace canary /tmp/artifacts/go-canary.zip
+      - deploy:
+          name: Deploy Go theme to the staging site
+          command: |
+            curl -X POST https://a90.8f7.myftpupload.com/webhook-wp-cli.php \
+            -H 'Content-Type: application/json' \
+            -H 'X-Authorization: Bearer ${STAGING_SITE_X_AUTHORIZATION}' \
+            -d '[ ["theme", "install"], ["https://github.com/godaddy-wordpress/go/releases/download/canary/go-canary.zip"], ["force"] ]'
+
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,6 @@ jobs:
             -H 'X-Authorization: Bearer ${STAGING_SITE_X_AUTHORIZATION}' \
             -d '[ ["theme", "install"], ["https://github.com/godaddy-wordpress/go/releases/download/canary/go-canary.zip"], ["force"] ]'
 
-
   deploy:
     docker:
       - image: circleci/golang:latest-node-browsers-legacy


### PR DESCRIPTION
Introduce a new method for deploying the Canary zip to the Go staging site.