### PR TITLE
Remove languages from tagged releases, keep MO files in canary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,6 +409,7 @@ jobs:
             mkdir -p go
             mkdir -p /tmp/artifacts
             rsync -av --exclude-from ~/project/.distignore --delete ~/project/. ./go
+            rm -rf go/languages
             zip -r /tmp/artifacts/go.zip ./go
       - deploy:
           name: Deploy a new release to GitHub

--- a/.distignore
+++ b/.distignore
@@ -10,5 +10,7 @@ package*.json
 README.md
 bin/
 build/
+languages/*.json
 languages/*.po
+languages/*.pot
 vendor/


### PR DESCRIPTION
* Make Go releases mimic what we do in CoBlocks in regards to languages
* Removes the `languages/` dir from tagged releases completely, users should get these from WordPress.org automatically
* Keeps `languages/*.mo` files in canary release for testing
* Should reduce the overall release size substantially (~500KB)