### PR TITLE
Enhance the slide out cart

### DIFF
--- a/.dev/assets/shared/css/woocommerce/button.css
+++ b/.dev/assets/shared/css/woocommerce/button.css
@@ -19,7 +19,9 @@ body {
 		& .button.disabled,
 		& .button.alt.disabled,
 		& .button.disabled:hover,
-		& .button.alt.disabled:hover {
+		& .button.alt.disabled:hover,
+		& .woocommerce button.button:disabled,
+		& .woocommerce button.button:disabled[disabled] {
 			@mixin button;
 		}
 

--- a/.dev/assets/shared/css/woocommerce/button.css
+++ b/.dev/assets/shared/css/woocommerce/button.css
@@ -65,6 +65,16 @@ body {
 			}
 		}
 	}
+
+	& .widget_shopping_cart a.wc-forward {
+		@mixin button;
+
+		&:hover,
+		&:focus,
+		&:active {
+			@mixin button-hover;
+		}
+	}
 }
 
 /* Buttons found on full product pages */

--- a/.dev/assets/shared/css/woocommerce/slideout-menu.css
+++ b/.dev/assets/shared/css/woocommerce/slideout-menu.css
@@ -3,6 +3,18 @@ body {
 	&.sidebar-move {
 		right: 480px;
 	}
+
+	&.woocommerce-checkout .woocommerce.widget_shopping_cart {
+
+		& a.remove_from_cart_button,
+		& .woocommerce-mini-cart__buttons a.checkout {
+			display: none;
+		}
+
+		& .cart_list li {
+			padding-left: 0;
+		}
+	}
 }
 
 .site-overlay {

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -59,6 +59,8 @@ function setup() {
 
 	add_action( 'wp', $n( 'disable_cart' ) );
 
+	add_filter( 'woocommerce_widget_cart_is_hidden', $n( 'show_widget_cart_on_checkout' ) );
+
 }
 
 /**
@@ -364,6 +366,17 @@ function disable_cart() {
 
 	add_filter( 'go_wc_use_slideout_cart', '__return_false' );
 	add_filter( 'go_wc_show_cart_menu', '__return_false' );
+
+}
+
+/**
+ * Enable the WooCommerce cart widget on the checkout page
+ *
+ * @return bool True when the cart should be disabled, else false.
+ */
+function show_widget_cart_on_checkout() {
+
+	return is_cart() ? true : false;
 
 }
 


### PR DESCRIPTION
Resolves #487 

- Enable the slide out cart on the checkout page.
- Remove the ability to remove items from the cart on the checkout page.
- Remove 'Checkout' button in slide out cart on the checkout page.
- Fix slide out cart button styles when on a non page without a `.woocommerce-page` class.
- Fix 'Update Cart' button styles when it is disabled.