### PR TITLE
Fix copyright footer text save error

### DIFF
--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -343,7 +343,7 @@ function register_global_controls( \WP_Customize_Manager $wp_customize ) {
 		array(
 			'default'           => \Go\Core\get_default_copyright(),
 			'transport'         => 'postMessage',
-			'sanitize_callback' => array( 'Go\Customizer', 'copyright_kses_html' ),
+			'sanitize_callback' => __NAMESPACE__ . '\\copyright_kses_html',
 		)
 	);
 


### PR DESCRIPTION
This PR fixes the copyright footer `sanitize_callback` not running, and thus custom copyright footer text not being able to save.