### PR TITLE
Add color controls to Site Design panel

### DIFF
--- a/.dev/assets/admin/css/style-customize.css
+++ b/.dev/assets/admin/css/style-customize.css
@@ -22,15 +22,6 @@
 	}
 }
 
-#customize-control-social_icon_color {
-	margin-top: 10px;
-}
-
-#customize-control-header_background_color,
-#customize-control-footer_background_color {
-	margin-top: 5px;
-}
-
 .home .entry-header.page-header {
 	display: none;
 }
@@ -38,4 +29,23 @@
 /* Hide the control while experimental */
 #customize-control-viewport_basis {
 	display: none !important;
+}
+
+.customize-control-go_title {
+	border-top: 1px solid #ddd;
+	margin-top: 12px;
+	padding-top: 20px;
+
+	& .customize-control-title {
+		line-height: 1.75;
+		margin-bottom: 4px;
+	}
+}
+
+.customize-control-color {
+
+	& .customize-control-title {
+		font-size: 13px;
+		font-weight: 500;
+	}
 }

--- a/.dev/assets/admin/js/customize-controls.js
+++ b/.dev/assets/admin/js/customize-controls.js
@@ -72,6 +72,7 @@ import './customize/controls/range-control';
 
 		// Only show the Footer Header Color selector, if the footer variation is 2 or 4.
 		customizerOptionDisplay( 'footer_variation', 'footer_heading_color', [ 'footer-3', 'footer-4' ] );
+		customizerOptionDisplay( 'footer_variation', 'footer_heading_color_alt', [ 'footer-3', 'footer-4' ] );
 
 		// Footer nav locations #2 and #3 are only available on Footer Variation #3 and #4.
 		customizerOptionDisplay( 'footer_variation', 'nav_menu_locations[footer-2]', [ 'footer-3', 'footer-4' ] );

--- a/.dev/tests/php/classes/customizer/test-title-control.php
+++ b/.dev/tests/php/classes/customizer/test-title-control.php
@@ -1,0 +1,84 @@
+<?php
+
+class Test_Class_Title_Control extends WP_UnitTestCase {
+
+	function setUp() {
+
+		parent::setUp();
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		require_once( ABSPATH . WPINC . '/class-wp-customize-manager.php' );
+
+		global $wp_customize;
+
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
+		$GLOBALS['wp_customize']->setup_theme();
+		$GLOBALS['wp_customize']->register_controls();
+
+		require_once get_parent_theme_file_path( 'includes/classes/customizer/class-title-control.php' );
+
+	}
+
+	function tearDown() {
+
+		parent::tearDown();
+
+	}
+
+	protected static function getMethod( $name ) {
+		$class  = new ReflectionClass( 'Go\Customizer\Title_Control' );
+		$method = $class->getMethod($name);
+		$method->setAccessible(true);
+		return $method;
+	}
+
+	/**
+	 * Test the switcher_type property returns as expected
+	 */
+	function test_title_control_property_switcher_type() {
+
+		$switcher_class = new Go\Customizer\Title_Control( $GLOBALS['wp_customize'], 'control-id' );
+		$reflection     = new ReflectionClass( $switcher_class );
+		$property       = $reflection->getProperty( 'switcher_type' );
+
+		$property->setAccessible( true );
+
+		$this->assertEquals( 'default', $property->getValue( $switcher_class ) );
+
+	}
+
+	/**
+	 * Test the type property returns as expected
+	 */
+	function test_title_control_property_type() {
+
+		$this->assertEquals( 'go_title', ( new Go\Customizer\Title_Control( $GLOBALS['wp_customize'], 'control-id' ) )->type );
+
+	}
+
+	/**
+	 * Test render_content method exists
+	 */
+	function test_title_control_render_content_method() {
+
+		$this->assertTrue( method_exists( new Go\Customizer\Title_Control( $GLOBALS['wp_customize'], 'control-id' ), 'render_content' ) );
+
+	}
+
+	/**
+	 * Test content_template method returns expected markup
+	 */
+	function test_title_control_content_template() {
+
+		$class  = new ReflectionClass( 'Go\Customizer\Title_Control' );
+		$method = $class->getMethod( 'content_template' );
+
+		$method->setAccessible( true );
+
+		$this->expectOutputRegex( '/<# if \( data.label \) { #>\\n[\n\r\s]+<span class="customize-control-title">{{ data.label }}<\/span>\\n[\n\r\s]+<# } #>\\n[\n\r\s]+<# if \( data.description \) { #>\\n[\n\r\s]+<em>{{ data.description }}<\/em>\\n[\n\r\s]+<# } #>/' );
+
+		$method->invokeArgs( new Go\Customizer\Title_Control( $GLOBALS['wp_customize'], 'control-id' ), [] );
+
+	}
+}

--- a/.dev/tests/php/test-customizer.php
+++ b/.dev/tests/php/test-customizer.php
@@ -192,6 +192,7 @@ class Test_Customizer extends WP_UnitTestCase {
 		$expected = [
 			'Go\Customizer\Switcher_Control',
 			'Go\Customizer\Range_Control',
+			'Go\Customizer\Title_Control',
 		];
 
 		$this->assertEquals( $expected, $instance->getValue( $manager ) );
@@ -687,6 +688,182 @@ class Test_Customizer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the title_header_colors setting is registered
+	 */
+	function test_register_header_controls_title_header_colors_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'title_header_colors' ) );
+
+	}
+
+	/**
+	 * Test the title_header_colors control is registered
+	 */
+	function test_register_header_controls_title_header_colors_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'title_header_colors_control' ) );
+
+	}
+
+	/**
+	 * Test the header_background_color setting is registered
+	 */
+	function test_register_color_controls_header_background_color_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'header_background_color' ) );
+
+	}
+
+	/**
+	 * Test the tertiary_color_control control is registered
+	 */
+	function test_register_color_controls_header_background_color_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'header_background_color_control' ) );
+
+	}
+
+	/**
+	 * Test the header_text_color setting is registered
+	 */
+	function test_register_header_controls_header_text_color_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'header_text_color' ) );
+
+	}
+
+	/**
+	 * Test the header_text_color_control control is registered
+	 */
+	function test_register_header_controls_header_text_color_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'header_text_color_control' ) );
+
+	}
+
+	/**
+	 * Test the title_footer_colors setting is registered
+	 */
+	function test_register_header_controls_title_footer_colors_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'title_footer_colors' ) );
+
+	}
+
+	/**
+	 * Test the title_footer_colors_control control is registered
+	 */
+	function test_register_header_controls_title_footer_colors_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'title_footer_colors_control' ) );
+
+	}
+
+	/**
+	 * Test the footer_background_color setting is registered
+	 */
+	function test_register_header_controls_footer_background_color_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'footer_background_color' ) );
+
+	}
+
+	/**
+	 * Test the footer_background_color_control control is registered
+	 */
+	function test_register_header_controls_footer_background_color_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'footer_background_color_control' ) );
+
+	}
+
+	/**
+	 * Test the footer_text_color setting is registered
+	 */
+	function test_register_footer_controls_footer_text_color_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'footer_text_color' ) );
+
+	}
+
+	/**
+	 * Test the footer_text_color control is registered
+	 */
+	function test_register_footer_controls_footer_text_color_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'footer_text_color' ) );
+
+	}
+
+	/**
+	 * Test the footer_heading_color setting is registered
+	 */
+	function test_register_footer_controls_footer_heading_color_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'footer_heading_color' ) );
+
+	}
+
+	/**
+	 * Test the footer_heading_color control is registered
+	 */
+	function test_register_footer_controls_footer_heading_color_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'footer_heading_color' ) );
+
+	}
+
+	/**
+	 * Test the social_icon_color setting is registered
+	 */
+	function test_register_color_controls_social_icon_color_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'social_icon_color' ) );
+
+	}
+
+	/**
+	 * Test the social_icon_color control is registered
+	 */
+	function test_register_color_controls_social_icon_color_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'social_icon_color' ) );
+
+	}
+
+	/**
 	 * Test the go_header_settings section is registered
 	 */
 	function test_register_header_controls_go_site_settings_section() {
@@ -720,50 +897,6 @@ class Test_Customizer extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the header_background_color setting is registered
-	 */
-	function test_register_header_controls_header_background_color_setting() {
-
-		Go\Customizer\register_header_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'header_background_color' ) );
-
-	}
-
-	/**
-	 * Test the header_background_color_control control is registered
-	 */
-	function test_register_header_controls_header_background_color_control() {
-
-		Go\Customizer\register_header_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'header_background_color_control' ) );
-
-	}
-
-	/**
-	 * Test the header_text_color setting is registered
-	 */
-	function test_register_header_controls_header_text_color_setting() {
-
-		Go\Customizer\register_header_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'header_text_color' ) );
-
-	}
-
-	/**
-	 * Test the header_text_color_control control is registered
-	 */
-	function test_register_header_controls_header_text_color_control() {
-
-		Go\Customizer\register_header_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'header_text_color_control' ) );
-
-	}
-
-	/**
 	 * Test the go_footer_settings section is registered
 	 */
 	function test_register_footer_controls_go_footer_settings_section() {
@@ -793,72 +926,6 @@ class Test_Customizer extends WP_UnitTestCase {
 		Go\Customizer\register_footer_controls( $GLOBALS['wp_customize'] );
 
 		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'footer_variation_control' ) );
-
-	}
-
-	/**
-	 * Test the footer_background_color setting is registered
-	 */
-	function test_register_footer_controls_footer_background_color_setting() {
-
-		Go\Customizer\register_footer_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'footer_background_color' ) );
-
-	}
-
-	/**
-	 * Test the footer_background_color_control control is registered
-	 */
-	function test_register_footer_controls_footer_background_color_control() {
-
-		Go\Customizer\register_footer_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'footer_background_color_control' ) );
-
-	}
-
-	/**
-	 * Test the footer_heading_color setting is registered
-	 */
-	function test_register_footer_controls_footer_heading_color_setting() {
-
-		Go\Customizer\register_footer_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'footer_heading_color' ) );
-
-	}
-
-	/**
-	 * Test the footer_heading_color control is registered
-	 */
-	function test_register_footer_controls_footer_heading_color_control() {
-
-		Go\Customizer\register_footer_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'footer_heading_color' ) );
-
-	}
-
-	/**
-	 * Test the footer_text_color setting is registered
-	 */
-	function test_register_footer_controls_footer_text_color_setting() {
-
-		Go\Customizer\register_footer_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'footer_text_color' ) );
-
-	}
-
-	/**
-	 * Test the footer_text_color control is registered
-	 */
-	function test_register_footer_controls_footer_text_color_control() {
-
-		Go\Customizer\register_footer_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'footer_text_color' ) );
 
 	}
 
@@ -904,28 +971,6 @@ class Test_Customizer extends WP_UnitTestCase {
 		}
 
 		$this->assertTrue( true );
-
-	}
-
-	/**
-	 * Test the social_icon_color setting is registered
-	 */
-	function test_register_social_controls_social_icon_color_setting() {
-
-		Go\Customizer\register_social_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'social_icon_color' ) );
-
-	}
-
-	/**
-	 * Test the social_icon_color control is registered
-	 */
-	function test_register_social_controls_social_icon_color_control() {
-
-		Go\Customizer\register_social_controls( $GLOBALS['wp_customize'] );
-
-		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'social_icon_color' ) );
 
 	}
 

--- a/includes/classes/customizer/class-title-control.php
+++ b/includes/classes/customizer/class-title-control.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Title Customizer Control.
+ *
+ * @package Go\Customizer
+ */
+
+namespace Go\Customizer;
+
+/**
+ * Switcher Control Class.
+ */
+class Title_Control extends \WP_Customize_Control {
+
+	/**
+	 * Holds the switcher type
+	 *
+	 * @var string
+	 */
+	protected $switcher_type = 'default';
+
+	/**
+	 * The slug of this control in the customizer.
+	 *
+	 * @var string
+	 */
+	public $type = 'go_title';
+
+	/**
+	 * The control is rendered in JS not PHP.
+	 *
+	 * @return void
+	 */
+	public function render_content() {}
+
+	/**
+	 * Renders the JS template for the control
+	 *
+	 * @return void
+	 */
+	protected function content_template() {
+		?>
+
+		<# if ( data.label ) { #>
+			<span class="customize-control-title">{{ data.label }}</span>
+		<# } #>
+
+		<# if ( data.description ) { #>
+			<em>{{ data.description }}</em>
+		<# } #>
+
+		<?php
+	}
+}

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -508,7 +508,7 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 	$wp_customize->add_control(
 		new Title_Control(
 			$wp_customize,
-			'title_header_colors',
+			'title_header_colors_control',
 			array(
 				'type'        => 'go_title',
 				'label'       => esc_html__( 'Header Colors', 'go' ),
@@ -570,7 +570,7 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 	$wp_customize->add_control(
 		new Title_Control(
 			$wp_customize,
-			'title_footer_colors',
+			'title_footer_colors_control',
 			array(
 				'type'        => 'go_title',
 				'label'       => esc_html__( 'Footer Colors', 'go' ),

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -53,8 +53,13 @@ function register_control_types( \WP_Customize_Manager $wp_customize ) {
 	// phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
 	require_once get_parent_theme_file_path( 'includes/classes/customizer/class-range-control.php' );
 
+	// This file is a class for our Customizer range control, not template partials.
+	// phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
+	require_once get_parent_theme_file_path( 'includes/classes/customizer/class-title-control.php' );
+
 	$wp_customize->register_control_type( Switcher_Control::class );
 	$wp_customize->register_control_type( Range_Control::class );
+	$wp_customize->register_control_type( Title_Control::class );
 }
 
 /**
@@ -416,7 +421,7 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 			$wp_customize,
 			'color_scheme_control',
 			array(
-				'label'         => esc_html__( 'Color Scheme', 'go' ),
+				'label'         => esc_html__( 'Color scheme', 'go' ),
 				'section'       => 'colors',
 				'settings'      => 'color_scheme',
 				'choices'       => get_color_schemes_as_choices(),
@@ -492,6 +497,170 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 		)
 	);
 
+	// Header colors.
+	$wp_customize->add_setting(
+		'title_header_colors',
+		array(
+			'sanitize_callback' => 'esc_html',
+		)
+	);
+
+	$wp_customize->add_control(
+		new Title_Control(
+			$wp_customize,
+			'title_header_colors',
+			array(
+				'type'        => 'go_title',
+				'label'       => esc_html__( 'Header Colors', 'go' ),
+				'description' => __( 'Customize colors within the site header.', 'go' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'header_background_color',
+		array(
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'sanitize_hex_color',
+			'default'           => \Go\get_default_palette_color( 'header_background' ),
+		)
+	);
+
+	$wp_customize->add_control(
+		new \WP_Customize_Color_Control(
+			$wp_customize,
+			'header_background_color_control',
+			array(
+				'label'    => esc_html__( 'Background', 'go' ),
+				'section'  => 'colors',
+				'settings' => 'header_background_color',
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'header_text_color',
+		array(
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new \WP_Customize_Color_Control(
+			$wp_customize,
+			'header_text_color_control',
+			array(
+				'label'    => esc_html__( 'Foreground', 'go' ),
+				'section'  => 'colors',
+				'settings' => 'header_text_color',
+			)
+		)
+	);
+
+	// Footer colors.
+	$wp_customize->add_setting(
+		'title_footer_colors',
+		array(
+			'sanitize_callback' => 'esc_html',
+		)
+	);
+
+	$wp_customize->add_control(
+		new Title_Control(
+			$wp_customize,
+			'title_footer_colors',
+			array(
+				'type'        => 'go_title',
+				'label'       => esc_html__( 'Footer Colors', 'go' ),
+				'description' => __( 'Customize colors within the site footer.', 'go' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'footer_background_color',
+		array(
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'sanitize_hex_color',
+			'default'           => \Go\get_default_palette_color( 'footer_background' ),
+		)
+	);
+
+	$wp_customize->add_control(
+		new \WP_Customize_Color_Control(
+			$wp_customize,
+			'footer_background_color_control',
+			array(
+				'label'    => esc_html__( 'Background', 'go' ),
+				'section'  => 'colors',
+				'settings' => 'footer_background_color',
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'footer_text_color',
+		array(
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new \WP_Customize_Color_Control(
+			$wp_customize,
+			'footer_text_color',
+			array(
+				'label'    => esc_html__( 'Foreground', 'go' ),
+				'section'  => 'colors',
+				'settings' => 'footer_text_color',
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'footer_heading_color',
+		array(
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new \WP_Customize_Color_Control(
+			$wp_customize,
+			'footer_heading_color',
+			array(
+				'label'    => esc_html__( 'Heading', 'go' ),
+				'section'  => 'colors',
+				'settings' => 'footer_heading_color',
+			)
+		)
+	);
+
+	$wp_customize->add_setting(
+		'social_icon_color',
+		array(
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new \WP_Customize_Color_Control(
+			$wp_customize,
+			'social_icon_color',
+			array(
+				'label'    => esc_html__( 'Social Icon', 'go' ),
+				'section'  => 'colors',
+				'settings' => 'social_icon_color',
+			)
+		)
+	);
+
 	$wp_customize->add_setting(
 		'viewport_basis',
 		array(
@@ -518,6 +687,7 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 			)
 		)
 	);
+
 }
 
 /**
@@ -560,41 +730,26 @@ function register_header_controls( \WP_Customize_Manager $wp_customize ) {
 		)
 	);
 
-	$wp_customize->add_setting(
-		'header_background_color',
-		array(
-			'transport'         => 'postMessage',
-			'sanitize_callback' => 'sanitize_hex_color',
-			'default'           => \Go\get_default_palette_color( 'header_background' ),
-		)
-	);
-
+	// Alternate color control.
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
-			'header_background_color_control',
+			'header_background_color_control_alt',
 			array(
-				'label'    => esc_html__( 'Background Color', 'go' ),
+				'label'    => esc_html__( 'Background', 'go' ),
 				'section'  => 'go_header_settings',
 				'settings' => 'header_background_color',
 			)
 		)
 	);
 
-	$wp_customize->add_setting(
-		'header_text_color',
-		array(
-			'transport'         => 'postMessage',
-			'sanitize_callback' => 'sanitize_hex_color',
-		)
-	);
-
+	// Alternate color control.
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
-			'header_text_color_control',
+			'header_text_color_control_alt',
 			array(
-				'label'    => esc_html__( 'Text Color', 'go' ),
+				'label'    => esc_html__( 'Foreground', 'go' ),
 				'section'  => 'go_header_settings',
 				'settings' => 'header_text_color',
 			)
@@ -642,63 +797,41 @@ function register_footer_controls( \WP_Customize_Manager $wp_customize ) {
 		)
 	);
 
-	$wp_customize->add_setting(
-		'footer_background_color',
-		array(
-			'transport'         => 'postMessage',
-			'sanitize_callback' => 'sanitize_hex_color',
-			'default'           => \Go\get_default_palette_color( 'footer_background' ),
-		)
-	);
-
+	// Alternate color control.
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
-			'footer_background_color_control',
+			'footer_background_color_control_alt',
 			array(
-				'label'    => esc_html__( 'Background Color', 'go' ),
+				'label'    => esc_html__( 'Background', 'go' ),
 				'section'  => 'go_footer_settings',
 				'settings' => 'footer_background_color',
 			)
 		)
 	);
 
-	$wp_customize->add_setting(
-		'footer_heading_color',
-		array(
-			'transport'         => 'postMessage',
-			'sanitize_callback' => 'sanitize_hex_color',
-		)
-	);
-
+	// Alternate color control.
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
-			'footer_heading_color',
+			'footer_text_color_alt',
 			array(
-				'label'    => esc_html__( 'Heading Color', 'go' ),
+				'label'    => esc_html__( 'Foreground', 'go' ),
 				'section'  => 'go_footer_settings',
-				'settings' => 'footer_heading_color',
+				'settings' => 'footer_text_color',
 			)
 		)
 	);
 
-	$wp_customize->add_setting(
-		'footer_text_color',
-		array(
-			'transport'         => 'postMessage',
-			'sanitize_callback' => 'sanitize_hex_color',
-		)
-	);
-
+	// Alternate color control.
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
-			'footer_text_color',
+			'footer_heading_color_alt',
 			array(
-				'label'    => esc_html__( 'Text Color', 'go' ),
+				'label'    => esc_html__( 'Heading', 'go' ),
 				'section'  => 'go_footer_settings',
-				'settings' => 'footer_text_color',
+				'settings' => 'footer_heading_color',
 			)
 		)
 	);
@@ -717,7 +850,7 @@ function register_social_controls( \WP_Customize_Manager $wp_customize ) {
 		'go_social_media',
 		array(
 			'title'       => esc_html__( 'Social', 'go' ),
-			'description' => 'Add social media account links to apply social icons to the footer of your site.',
+			'description' => esc_html__( 'Add social media account links to apply social icons on the site footer.', 'go' ),
 			'priority'    => 90,
 		)
 	);
@@ -747,20 +880,13 @@ function register_social_controls( \WP_Customize_Manager $wp_customize ) {
 		);
 	}
 
-	$wp_customize->add_setting(
-		'social_icon_color',
-		array(
-			'transport'         => 'postMessage',
-			'sanitize_callback' => 'sanitize_hex_color',
-		)
-	);
-
+	// Alternate color control.
 	$wp_customize->add_control(
 		new \WP_Customize_Color_Control(
 			$wp_customize,
-			'social_icon_color',
+			'social_icon_color_alt',
 			array(
-				'label'    => esc_html__( 'Icon Color', 'go' ),
+				'label'    => esc_html__( 'Social icon', 'go' ),
 				'section'  => 'go_social_media',
 				'settings' => 'social_icon_color',
 			)


### PR DESCRIPTION
This PR adds color pickers to the Site Design panel within the Customizer, consolidating our design tools into one panel. Closes #454 
![ScreenFlow](https://user-images.githubusercontent.com/1813435/79144327-c8718e00-7d8c-11ea-823e-ee507fd83ea3.gif)
