### PR TITLE
Remove customize-preview dependency from go-customize-preview

### DIFF
--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -168,7 +168,7 @@ function customize_preview_init() {
 	wp_enqueue_script(
 		'go-customize-preview',
 		get_theme_file_uri( "dist/js/admin/customize-preview{$suffix}.js" ),
-		array( 'jquery', 'customize-preview', 'wp-autop' ),
+		array( 'jquery', 'wp-autop' ),
 		GO_VERSION,
 		true
 	);


### PR DESCRIPTION
Prevent the `customize_changeset_uuid` from being appended on initial customizer loads by removing the customize-preview dependency from the `go-customize-preview` script.