### PR TITLE
Add viewport basis Customizer controls

### DIFF
--- a/.dev/assets/admin/css/style-customize.css
+++ b/.dev/assets/admin/css/style-customize.css
@@ -28,6 +28,11 @@
 
 #customize-control-viewport_basis {
 	direction: rtl;
+
+	& .customize-control-title {
+		font-size: 13px;
+		font-weight: 500;
+	}
 }
 
 .customize-control-go_title {

--- a/.dev/assets/admin/css/style-customize.css
+++ b/.dev/assets/admin/css/style-customize.css
@@ -26,9 +26,8 @@
 	display: none;
 }
 
-/* Hide the control while experimental */
 #customize-control-viewport_basis {
-	display: none !important;
+	direction: rtl;
 }
 
 .customize-control-go_title {

--- a/.dev/tests/php/test-customizer.php
+++ b/.dev/tests/php/test-customizer.php
@@ -977,6 +977,29 @@ class Test_Customizer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the viewport_basis setting is registered
+	 */
+	function test_register_color_viewport_basis_setting() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'viewport_basis' ) );
+
+	}
+
+	/**
+	 * Test the viewport_basis control is registered
+	 */
+	function test_register_viewport_basis_control() {
+
+		Go\Customizer\register_color_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'viewport_basis' ) );
+
+	}
+
+
+	/**
 	 * Test the rename_panels renames the colors panel properly
 	 */
 	function test_rename_panels_colors() {

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -671,20 +671,17 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 	);
 
 	$wp_customize->add_control(
-		new Range_Control(
-			$wp_customize,
-			'viewport_basis',
-			array(
-				'default'     => \Go\Core\get_default_viewport_basis(),
-				'type'        => 'go_range_control',
-				'label'       => esc_html__( 'Spacing', 'go' ),
-				'section'     => 'colors',
-				'input_attrs' => array(
-					'min'  => 500,
-					'max'  => 2250,
-					'step' => 1,
-				),
-			)
+		'viewport_basis',
+		array(
+			'default'     => \Go\Core\get_default_viewport_basis(),
+			'type'   => 'range',
+			'label'       => esc_html__( 'Spacing', 'go' ),
+			'section'     => 'colors',
+			'input_attrs' => array(
+				'min'  => 500,
+				'max'  => 2250,
+				'step' => 1,
+			),
 		)
 	);
 

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -674,7 +674,7 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 		'viewport_basis',
 		array(
 			'default'     => \Go\Core\get_default_viewport_basis(),
-			'type'   => 'range',
+			'type'        => 'range',
 			'label'       => esc_html__( 'Spacing', 'go' ),
 			'section'     => 'colors',
 			'input_attrs' => array(
@@ -1006,7 +1006,7 @@ function inline_css() {
 					--go-logo-mobile--max-width: <?php echo esc_attr( $logo_width_mobile ); ?>px;
 				<?php endif; ?>
 
-				<?php if ( false === $viewport_basis ) : ?>
+				<?php if ( $viewport_basis ) : ?>
 					--go--viewport-basis: <?php echo esc_attr( $viewport_basis ); ?>;
 				<?php endif; ?>
 			}

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -661,6 +661,27 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 		)
 	);
 
+	// Footer colors.
+	$wp_customize->add_setting(
+		'title_site_styles',
+		array(
+			'sanitize_callback' => 'esc_html',
+		)
+	);
+
+	$wp_customize->add_control(
+		new Title_Control(
+			$wp_customize,
+			'title_site_styles',
+			array(
+				'type'        => 'go_title',
+				'label'       => esc_html__( 'Additional Design Controls', 'go' ),
+				'description' => __( 'Customize additional design settings.', 'go' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
 	$wp_customize->add_setting(
 		'viewport_basis',
 		array(
@@ -675,7 +696,7 @@ function register_color_controls( \WP_Customize_Manager $wp_customize ) {
 		array(
 			'default'     => \Go\Core\get_default_viewport_basis(),
 			'type'        => 'range',
-			'label'       => esc_html__( 'Spacing', 'go' ),
+			'label'       => esc_html__( 'Site Spacing', 'go' ),
 			'section'     => 'colors',
 			'input_attrs' => array(
 				'min'  => 500,


### PR DESCRIPTION
Enable viewport basis controls for Go theme. New controls are located within the theme Customizer under the Site Design section. Closes #450.

![viewportBasisControl](https://user-images.githubusercontent.com/30462574/80237998-81985980-8612-11ea-8f8b-8fc8030312e9.gif)

Using core range controls.
Added tests for new setting and control.