### PR TITLE
Resolve featured image text color bug

### DIFF
--- a/.dev/assets/shared/css/layout/featured-image.css
+++ b/.dev/assets/shared/css/layout/featured-image.css
@@ -55,17 +55,3 @@
 		}
 	}
 }
-
-.has-featured-image:not(.is-style-welcoming):not(.menu-is-open) {
-
-	& .site-title,
-	& .site-description,
-	& .header .primary-menu a {
-		color: var(--go--color--white);
-	}
-
-	& .nav-toggle-icon svg,
-	& .header__search-toggle svg {
-		fill: var(--go--color--white) !important;
-	}
-}


### PR DESCRIPTION
This PR resolves an issue where the featured image causes text to be `#fff` on pages with them.

Before: 
<img width="1489" alt="Screen Shot 2020-04-24 at 3 27 38 PM" src="https://user-images.githubusercontent.com/1813435/80249633-3137f080-8640-11ea-8f67-841fd470a12f.png">

After:
<img width="1489" alt="Screen Shot 2020-04-24 at 3 27 24 PM" src="https://user-images.githubusercontent.com/1813435/80249647-35fca480-8640-11ea-8ea7-5787c459b37d.png">
