### PR TITLE
Add Events block styles to shared theme styles

### DIFF
--- a/.dev/assets/shared/css/coblocks/events.css
+++ b/.dev/assets/shared/css/coblocks/events.css
@@ -1,9 +1,35 @@
 /*! CoBlocks: Events */
 .wp-block-coblocks-events__title,
 .wp-block-coblocks-events__day,
-.wp-block-coblocks-events__time {
+.wp-block-coblocks-events__time,
+.wp-block-coblocks-events__month,
+.wp-block-coblocks-events__year,
+.wp-block-coblocks-events__location {
 	font-family: var(--go-heading--font-family);
 	font-style: var(--go-heading--font-style, normal);
 	font-weight: var(--go-heading--font-weight);
 	line-height: var(--go-heading--line-height);
+}
+
+.wp-block-coblocks-events__title {
+	font-size: var(--go--type-scale-3);
+}
+
+.wp-block-coblocks-events__day {
+	font-size: var(--go--type-scale-4);
+}
+
+.wp-block-coblocks-events__time,
+.wp-block-coblocks-events__month,
+.wp-block-coblocks-events__year {
+	font-size: var(--go--type-scale-1);
+}
+
+.wp-block-coblocks-events__location {
+	font-size: 100%;
+}
+
+.wp-block-coblocks-events__description {
+	font-size: 100%;
+	line-height: var(--go--line-height);
 }

--- a/.dev/assets/shared/css/coblocks/events.css
+++ b/.dev/assets/shared/css/coblocks/events.css
@@ -1,0 +1,9 @@
+/*! CoBlocks: Events */
+.wp-block-coblocks-events__title,
+.wp-block-coblocks-events__day,
+.wp-block-coblocks-events__time {
+	font-family: var(--go-heading--font-family);
+	font-style: var(--go-heading--font-style, normal);
+	font-weight: var(--go-heading--font-weight);
+	line-height: var(--go-heading--line-height);
+}

--- a/.dev/assets/shared/css/style-editor.css
+++ b/.dev/assets/shared/css/style-editor.css
@@ -34,12 +34,13 @@
 
 /* CoBlocks */
 @import url("coblocks/accordion.css");
-@import url("coblocks/pricing-table.css");
-@import url("coblocks/social.css");
-@import url("coblocks/services.css");
-@import url("coblocks/features.css");
 @import url("coblocks/carousel.css");
+@import url("coblocks/events.css");
+@import url("coblocks/features.css");
 @import url("coblocks/food-drinks.css");
+@import url("coblocks/pricing-table.css");
+@import url("coblocks/services.css");
+@import url("coblocks/social.css");
 
 .block-editor-block-list__block[data-type="core/paragraph"] p {
 	line-height: var(--go--line-height);

--- a/.dev/assets/shared/css/style-shared.css
+++ b/.dev/assets/shared/css/style-shared.css
@@ -76,23 +76,24 @@
 @import url("blocks/group.css");
 
 /*! CoBlocks */
+@import url("coblocks/accordion.css");
+@import url("coblocks/alert.css");
 @import url("coblocks/author.css");
-@import url("coblocks/form.css");
-@import url("coblocks/row.css");
+@import url("coblocks/carousel.css");
+@import url("coblocks/dynamic-separator.css");
+@import url("coblocks/events.css");
+@import url("coblocks/features.css");
 @import url("coblocks/food-drinks.css");
+@import url("coblocks/form.css");
+@import url("coblocks/hero.css");
 @import url("coblocks/icon.css");
 @import url("coblocks/masonry.css");
-@import url("coblocks/carousel.css");
-@import url("coblocks/accordion.css");
-@import url("coblocks/pricing-table.css");
-@import url("coblocks/services.css");
-@import url("coblocks/dynamic-separator.css");
-@import url("coblocks/social.css");
-@import url("coblocks/shape-divider.css");
-@import url("coblocks/alert.css");
-@import url("coblocks/hero.css");
-@import url("coblocks/features.css");
 @import url("coblocks/media-card.css");
+@import url("coblocks/pricing-table.css");
+@import url("coblocks/row.css");
+@import url("coblocks/services.css");
+@import url("coblocks/shape-divider.css");
+@import url("coblocks/social.css");
 
 /*! WooCommerce */
 @import url("woocommerce/notice.css");


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
PR to add CoBlocks Events block styles to Go theme. This allows the heading and paragraph typography variables to properly apply to the Events block.

### Screenshots
![eventsBlockStyles](https://user-images.githubusercontent.com/30462574/80499969-756a1000-8922-11ea-8b78-036ea9f962fc.gif)

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Styles added to reference theme variables.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested in 5.4 and 5.5beta.
Tested with and without the Gutenberg plugin running.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
