### PR TITLE
[Fix] Use `display_name` for the post author section.

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -116,7 +116,7 @@ function get_post_meta( $post_id = null, $location = 'top' ) {
 					<span class="meta-text">
 						<?php
 						// Translators: %s = the author name.
-						printf( esc_html_x( 'By %s', '%s = author name', 'go' ), '<a href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author_meta( 'nickname' ) ) . '</a>' );
+						printf( esc_html_x( 'By %s', '%s = author name', 'go' ), '<a href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author_meta( 'display_name' ) ) . '</a>' );
 						?>
 					</span>
 				</li>


### PR DESCRIPTION
### Description

Use `display_name` for the post author section. Resolves: https://github.com/godaddy-wordpress/go/issues/519

### Screenshots

<img src="https://cldup.com/pLogs9HKSm.png" />

### Types of changes

I changed the parameter for `get_the_author_meta()` to `display_name`. That way the post meta will respect what the user chose in their profile.

### How has this been tested?

- Go to my profile.
- Choose different values for **Display name publicly as**.
- Visit any post created by that user and confirm that the setting is respected in the FE.
