### PR TITLE
Fix gradient control

### DIFF
--- a/.dev/tests/php/test-template-tags.php
+++ b/.dev/tests/php/test-template-tags.php
@@ -841,6 +841,60 @@ class Test_Template_Tags extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that passing a empty HEX value returns false.
+	 */
+	public function test_hex_to_rgb_empty() {
+
+		$this->assertEquals( false, Go\hex_to_rgb( '' ) );
+
+	}
+
+	/**
+	 * Test that passing a color of invali length returns the default primary color.
+	 */
+	public function test_hex_to_rgb_invalid_length() {
+
+		$this->assertEquals( '#c76919', Go\hex_to_rgb( '#1234567' ) );
+
+	}
+
+	/**
+	 * Test that passing a HEX value of with six string length.
+	 */
+	public function test_hex_to_rgb_length_six() {
+
+		$this->assertEquals( 'rgb(199,105,25)', Go\hex_to_rgb( '#c76919' ) );
+
+	}
+
+	/**
+	 * Test that passing a HEX value of with three string length.
+	 */
+	public function test_hex_to_rgb_length_three() {
+
+		$this->assertEquals( 'rgb(204,119,102)', Go\hex_to_rgb( '#c76' ) );
+
+	}
+
+	/**
+	 * Test that passing a HEX value of with three string length.
+	 */
+	public function test_hex_to_rgb_with_opacity() {
+
+		$this->assertEquals( 'rgba(199,105,25,0.8)', Go\hex_to_rgb( '#c76919', '0.8' ) );
+
+	}
+
+	/**
+	 * Test that passing a HEX value of with three string length.
+	 */
+	public function test_hex_to_rgb_with_opacity_greater_than_one() {
+
+		$this->assertEquals( 'rgba(199,105,25,1)', Go\hex_to_rgb( '#c76919', '2' ) );
+
+	}
+
+	/**
 	 * Test that has_header_background returns null when no header_background is set in the color_scheme
 	 */
 	public function test_has_header_background_null() {

--- a/.dev/tests/php/test-template-tags.php
+++ b/.dev/tests/php/test-template-tags.php
@@ -264,34 +264,34 @@ class Test_Template_Tags extends WP_UnitTestCase {
 
 		$expected_primary_colors = [
 			'traditional' => [
-				'one'   => '#c76919',
-				'two'   => '#165153',
-				'three' => '#87200e',
-				'four'  => '#a88548',
+				'one'   => 'rgb(199,105,25)',
+				'two'   => 'rgb(22,81,83)',
+				'three' => 'rgb(135,32,14)',
+				'four'  => 'rgb(168,133,72)',
 			],
 			'modern'      => [
-				'one'   => '#000000',
-				'two'   => '#c2185b',
-				'three' => '#303f9f',
-				'four'  => '#00796b',
+				'one'   => 'rgb(0,0,0)',
+				'two'   => 'rgb(194,24,91)',
+				'three' => 'rgb(48,63,159)',
+				'four'  => 'rgb(0,121,107)',
 			],
 			'trendy'      => [
-				'one'   => '#000000',
-				'two'   => '#000000',
-				'three' => '#000000',
-				'four'  => '#000000',
+				'one'   => 'rgb(0,0,0)',
+				'two'   => 'rgb(0,0,0)',
+				'three' => 'rgb(0,0,0)',
+				'four'  => 'rgb(0,0,0)',
 			],
 			'welcoming'   => [
-				'one'   => '#165144',
-				'two'   => '#233a6b',
-				'three' => '#5b3f20',
-				'four'  => '#443a82',
+				'one'   => 'rgb(22,81,68)',
+				'two'   => 'rgb(35,58,107)',
+				'three' => 'rgb(91,63,32)',
+				'four'  => 'rgb(68,58,130)',
 			],
 			'playful'     => [
-				'one'   => '#3f46ae',
-				'two'   => '#e06b6d',
-				'three' => '#3c896d',
-				'four'  => '#117495',
+				'one'   => 'rgb(63,70,174)',
+				'two'   => 'rgb(224,107,109)',
+				'three' => 'rgb(60,137,109)',
+				'four'  => 'rgb(17,116,149)',
 			],
 		];
 
@@ -326,34 +326,34 @@ class Test_Template_Tags extends WP_UnitTestCase {
 
 		$expected_secondary_colors = [
 			'traditional' => [
-				'one'   => '#122538',
-				'two'   => '#212121',
-				'three' => '#242611',
-				'four'  => '#05212d',
+				'one'   => 'rgb(18,37,56)',
+				'two'   => 'rgb(33,33,33)',
+				'three' => 'rgb(36,38,17)',
+				'four'  => 'rgb(5,33,45)',
 			],
 			'modern'      => [
-				'one'   => '#455a64',
-				'two'   => '#ec407a',
-				'three' => '#5c6bc0',
-				'four'  => '#26a69a',
+				'one'   => 'rgb(69,90,100)',
+				'two'   => 'rgb(236,64,122)',
+				'three' => 'rgb(92,107,192)',
+				'four'  => 'rgb(38,166,154)',
 			],
 			'trendy'      => [
-				'one'   => '#4d0859',
-				'two'   => '#003c68',
-				'three' => '#02493b',
-				'four'  => '#cc224f',
+				'one'   => 'rgb(77,8,89)',
+				'two'   => 'rgb(0,60,104)',
+				'three' => 'rgb(2,73,59)',
+				'four'  => 'rgb(204,34,79)',
 			],
 			'welcoming'   => [
-				'one'   => '#01332e',
-				'two'   => '#01133d',
-				'three' => '#3f2404',
-				'four'  => '#2b226b',
+				'one'   => 'rgb(1,51,46)',
+				'two'   => 'rgb(1,19,61)',
+				'three' => 'rgb(63,36,4)',
+				'four'  => 'rgb(43,34,107)',
 			],
 			'playful'     => [
-				'one'   => '#ecb43d',
-				'two'   => '#40896e',
-				'three' => '#6b0369',
-				'four'  => '#d691c1',
+				'one'   => 'rgb(236,180,61)',
+				'two'   => 'rgb(64,137,110)',
+				'three' => 'rgb(107,3,105)',
+				'four'  => 'rgb(214,145,193)',
 			],
 		];
 
@@ -388,34 +388,34 @@ class Test_Template_Tags extends WP_UnitTestCase {
 
 		$expected_tertiary_colors = [
 			'traditional' => [
-				'one'   => '#f8f8f8',
-				'two'   => '#f3f1f0',
-				'three' => '#f9f2ef',
-				'four'  => '#f9f4ef',
+				'one'   => 'rgb(248,248,248)',
+				'two'   => 'rgb(243,241,240)',
+				'three' => 'rgb(249,242,239)',
+				'four'  => 'rgb(249,244,239)',
 			],
 			'modern'      => [
-				'one'   => '#eceff1',
-				'two'   => '#fce4ec',
-				'three' => '#e8eaf6',
-				'four'  => '#e0f2f1',
+				'one'   => 'rgb(236,239,241)',
+				'two'   => 'rgb(252,228,236)',
+				'three' => 'rgb(232,234,246)',
+				'four'  => 'rgb(224,242,241)',
 			],
 			'trendy'      => [
-				'one'   => '#ded9e2',
-				'two'   => '#c0c9d0',
-				'three' => '#b4c6af',
-				'four'  => '#e5dede',
+				'one'   => 'rgb(222,217,226)',
+				'two'   => 'rgb(192,201,208)',
+				'three' => 'rgb(180,198,175)',
+				'four'  => 'rgb(229,222,222)',
 			],
 			'welcoming'   => [
-				'one'   => '#c9c9c9',
-				'two'   => '#c9c9c9',
-				'three' => '#c9c9c9',
-				'four'  => '#c9c9c9',
+				'one'   => 'rgb(201,201,201)',
+				'two'   => 'rgb(201,201,201)',
+				'three' => 'rgb(201,201,201)',
+				'four'  => 'rgb(201,201,201)',
 			],
 			'playful'     => [
-				'one'   => '#f7fbff',
-				'two'   => '#fff7f7',
-				'three' => '#f2f9f7',
-				'four'  => '#f7feff',
+				'one'   => 'rgb(247,251,255)',
+				'two'   => 'rgb(255,247,247)',
+				'three' => 'rgb(242,249,247)',
+				'four'  => 'rgb(247,254,255)',
 			],
 		];
 
@@ -450,34 +450,34 @@ class Test_Template_Tags extends WP_UnitTestCase {
 
 		$expected_background_colors = [
 			'traditional' => [
-				'one'   => '#ffffff',
-				'two'   => '#ffffff',
-				'three' => '#ffffff',
-				'four'  => '#ffffff',
+				'one'   => 'rgb(255,255,255)',
+				'two'   => 'rgb(255,255,255)',
+				'three' => 'rgb(255,255,255)',
+				'four'  => 'rgb(255,255,255)',
 			],
 			'modern'      => [
-				'one'   => '#ffffff',
-				'two'   => '#ffffff',
-				'three' => '#ffffff',
-				'four'  => '#ffffff',
+				'one'   => 'rgb(255,255,255)',
+				'two'   => 'rgb(255,255,255)',
+				'three' => 'rgb(255,255,255)',
+				'four'  => 'rgb(255,255,255)',
 			],
 			'trendy'      => [
-				'one'   => '#ffffff',
-				'two'   => '#ffffff',
-				'three' => '#ffffff',
-				'four'  => '#ffffff',
+				'one'   => 'rgb(255,255,255)',
+				'two'   => 'rgb(255,255,255)',
+				'three' => 'rgb(255,255,255)',
+				'four'  => 'rgb(255,255,255)',
 			],
 			'welcoming'   => [
-				'one'   => '#eeeeee',
-				'two'   => '#eeeeee',
-				'three' => '#eeeeee',
-				'four'  => '#eeeeee',
+				'one'   => 'rgb(238,238,238)',
+				'two'   => 'rgb(238,238,238)',
+				'three' => 'rgb(238,238,238)',
+				'four'  => 'rgb(238,238,238)',
 			],
 			'playful'     => [
-				'one'   => '#ffffff',
-				'two'   => '#ffffff',
-				'three' => '#ffffff',
-				'four'  => '#ffffff',
+				'one'   => 'rgb(255,255,255)',
+				'two'   => 'rgb(255,255,255)',
+				'three' => 'rgb(255,255,255)',
+				'four'  => 'rgb(255,255,255)',
 			],
 		];
 
@@ -524,10 +524,10 @@ class Test_Template_Tags extends WP_UnitTestCase {
 				'four'  => null,
 			],
 			'trendy'      => [
-				'one'   => '#000000',
-				'two'   => '#000000',
-				'three' => '#000000',
-				'four'  => '#000000',
+				'one'   => 'rgb(0,0,0)',
+				'two'   => 'rgb(0,0,0)',
+				'three' => 'rgb(0,0,0)',
+				'four'  => 'rgb(0,0,0)',
 			],
 			'welcoming'   => [
 				'one'   => null,
@@ -536,10 +536,10 @@ class Test_Template_Tags extends WP_UnitTestCase {
 				'four'  => null,
 			],
 			'playful'     => [
-				'one'   => '#3f46ae',
-				'two'   => '#eb616a',
-				'three' => '#3c896d',
-				'four'  => '#117495',
+				'one'   => 'rgb(63,70,174)',
+				'two'   => 'rgb(235,97,106)',
+				'three' => 'rgb(60,137,109)',
+				'four'  => 'rgb(17,116,149)',
 			],
 		];
 
@@ -592,16 +592,16 @@ class Test_Template_Tags extends WP_UnitTestCase {
 				'four'  => null,
 			],
 			'welcoming'   => [
-				'one'   => '#ffffff',
-				'two'   => '#ffffff',
-				'three' => '#ffffff',
-				'four'  => '#ffffff',
+				'one'   => 'rgb(255,255,255)',
+				'two'   => 'rgb(255,255,255)',
+				'three' => 'rgb(255,255,255)',
+				'four'  => 'rgb(255,255,255)',
 			],
 			'playful'     => [
-				'one'   => '#3f46ae',
-				'two'   => '#eb616a',
-				'three' => '#3c896d',
-				'four'  => '#117495',
+				'one'   => 'rgb(63,70,174)',
+				'two'   => 'rgb(235,97,106)',
+				'three' => 'rgb(60,137,109)',
+				'four'  => 'rgb(17,116,149)',
 			],
 		];
 
@@ -636,7 +636,7 @@ class Test_Template_Tags extends WP_UnitTestCase {
 
 		set_theme_mod( 'header_background_color', '#B4D455' );
 
-		$this->assertEquals( '#B4D455', Go\get_palette_color( 'header_background' ) );
+		$this->assertEquals( 'rgb(180,212,85)', Go\get_palette_color( 'header_background' ) );
 
 	}
 

--- a/.dev/tests/php/test-title-meta.php
+++ b/.dev/tests/php/test-title-meta.php
@@ -57,6 +57,48 @@ class Test_Title_Meta extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test hide_page_title has no effect when on non-pages.
+	 */
+	function test_hide_page_title_callback() {
+
+		$post_title_visible = $this->factory->post->create(
+			[
+				'post_title' => 'Show Post title',
+				'post_type'  => 'post'
+			]
+		);
+
+		update_post_meta( $post_title_visible, 'hide_page_title', 'enabled' );
+
+		$post_title_hidden = $this->factory->post->create(
+			[
+				'post_title' => 'Hide Post title',
+				'post_type'  => 'post'
+			]
+		);
+
+		update_post_meta( $post_title_hidden, 'hide_page_title', 'disabled' );
+
+		$post_title_invalid_status = $this->factory->post->create(
+			[
+				'post_title' => 'Invalid Status Hide Post title',
+				'post_type'  => 'post'
+			]
+		);
+
+		update_post_meta( $post_title_invalid_status, 'hide_page_title', 'invalid-type' );
+
+		$test_data = [
+			get_post_meta( $post_title_visible, 'hide_page_title', true ),
+			get_post_meta( $post_title_hidden, 'hide_page_title', true ),
+			get_post_meta( $post_title_invalid_status, 'hide_page_title', true ),
+		];
+
+		$this->assertEquals( $test_data, [ 'enabled', 'disabled', '' ] );
+
+	}
+
+	/**
 	 * Test hide_page_title does not remove the title value when on pages where _hide_page_title is false.
 	 * (visible page titles)
 	 */

--- a/includes/core.php
+++ b/includes/core.php
@@ -227,10 +227,10 @@ function theme_setup() {
 
 		add_theme_support( 'editor-color-palette', $color_palette );
 
-		$primary_color    = \Go\get_palette_color( 'primary', 'RBG' );
-		$secondary_color  = \Go\get_palette_color( 'secondary', 'RBG' );
-		$tertiary_color   = \Go\get_palette_color( 'tertiary', 'RBG' );
-		$background_color = \Go\get_palette_color( 'background', 'RBG' );
+		$primary_color    = \Go\get_palette_color( 'primary', 'RGB' );
+		$secondary_color  = \Go\get_palette_color( 'secondary', 'RGB' );
+		$tertiary_color   = \Go\get_palette_color( 'tertiary', 'RGB' );
+		$background_color = \Go\get_palette_color( 'background', 'RGB' );
 
 		add_theme_support(
 			'editor-gradient-presets',

--- a/includes/core.php
+++ b/includes/core.php
@@ -227,37 +227,32 @@ function theme_setup() {
 
 		add_theme_support( 'editor-color-palette', $color_palette );
 
-		$primary_color    = \Go\get_palette_color( 'primary', 'HSL' );
-		$secondary_color  = \Go\get_palette_color( 'secondary', 'HSL' );
-		$tertiary_color   = \Go\get_palette_color( 'tertiary', 'HSL' );
-		$background_color = \Go\get_palette_color( 'background', 'HSL' );
-
-		$primary_hsl    = 'hsl(' . $primary_color[0] . ', ' . $primary_color[1] . '%, ' . $primary_color[2] . '%)';
-		$secondary_hsl  = 'hsl(' . $secondary_color[0] . ', ' . $secondary_color[1] . '%, ' . $secondary_color[2] . '%)';
-		$tertiary_hsl   = 'hsl(' . $tertiary_color[0] . ', ' . $tertiary_color[1] . '%, ' . $tertiary_color[2] . '%)';
-		$background_hsl = 'hsl(' . $background_color[0] . ', ' . $background_color[1] . '%, ' . $background_color[2] . '%)';
+		$primary_color    = \Go\get_palette_color( 'primary', 'RBG' );
+		$secondary_color  = \Go\get_palette_color( 'secondary', 'RBG' );
+		$tertiary_color   = \Go\get_palette_color( 'tertiary', 'RBG' );
+		$background_color = \Go\get_palette_color( 'background', 'RBG' );
 
 		add_theme_support(
 			'editor-gradient-presets',
 			array(
 				array(
 					'name'     => __( 'Primary to Secondary', 'go' ),
-					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $primary_hsl ) . ' 0%, ' . esc_attr( $secondary_hsl ) . ' 100%)',
+					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $primary_color ) . ' 0%, ' . esc_attr( $secondary_color ) . ' 100%)',
 					'slug'     => 'primary-to-secondary',
 				),
 				array(
 					'name'     => __( 'Primary to Tertiary', 'go' ),
-					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $primary_hsl ) . ' 0%, ' . esc_attr( $tertiary_hsl ) . ' 100%)',
+					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $primary_color ) . ' 0%, ' . esc_attr( $tertiary_color ) . ' 100%)',
 					'slug'     => 'primary-to-tertiary',
 				),
 				array(
 					'name'     => __( 'Primary to Background', 'go' ),
-					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $primary_hsl ) . ' 0%, ' . esc_attr( $background_hsl ) . ' 100%)',
+					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $primary_color ) . ' 0%, ' . esc_attr( $background_color ) . ' 100%)',
 					'slug'     => 'primary-to-background',
 				),
 				array(
 					'name'     => __( 'Secondary to Tertiary', 'go' ),
-					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $secondary_hsl ) . ' 0%, ' . esc_attr( $tertiary_hsl ) . ' 100%)',
+					'gradient' => 'linear-gradient(135deg, ' . esc_attr( $secondary_color ) . ' 0%, ' . esc_attr( $background_color ) . ' 100%)',
 					'slug'     => 'secondary-to-tertiary',
 				),
 			)

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -321,6 +321,10 @@ function get_palette_color( $color, $format = 'RBG' ) {
 		if ( 'HSL' === $format ) {
 			return hex_to_hsl( $the_color );
 		}
+
+		if ( 'RBG' === $format ) {
+			return hex_to_rbg( $the_color );
+		}
 	}
 
 	return $the_color;
@@ -360,9 +364,54 @@ function get_default_palette_color( $color, $format = 'RBG' ) {
 }
 
 /**
+ * Convert a 3- or 6-digit hexadecimal color to an associative RGB array.
+ *
+ * @param string $color The color in hex format.
+ * @param bool   $opacity Whether to return the RGB color is opaque.
+ *
+ * @return string
+ */
+function hex_to_rbg( $color, $opacity = false ) {
+
+	if ( empty( $color ) ) {
+		return false;
+	}
+
+	if ( '#' === $color[0] ) {
+		$color = substr( $color, 1 );
+	}
+
+	if ( 6 === strlen( $color ) ) {
+		$hex = array( $color[0] . $color[1], $color[2] . $color[3], $color[4] . $color[5] );
+	} elseif ( 3 === strlen( $color ) ) {
+		$hex = array( $color[0] . $color[0], $color[1] . $color[1], $color[2] . $color[2] );
+	} else {
+		return $default;
+	}
+
+	$rgb = array_map( 'hexdec', $hex );
+
+	if ( $opacity ) {
+		if ( abs( $opacity ) > 1 ) {
+			$opacity = 1.0;
+		}
+
+		$output = 'rgba(' . implode( ',', $rgb ) . ',' . $opacity . ')';
+
+	} else {
+
+		$output = 'rgb(' . implode( ',', $rgb ) . ')';
+
+	}
+
+	return esc_attr( $output );
+
+}
+
+/**
  * Converts a hex RGB color to HSL
  *
- * @param string $hex The RGB color in hex format.
+ * @param string $hex The HSL color in hex format.
  * @param bool   $string_output Whether to return the HSL color in CSS format.
  *
  * @return array

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -386,6 +386,11 @@ function hex_to_rgb( $color, $opacity = false ) {
 	} elseif ( 3 === strlen( $color ) ) {
 		$hex = array( $color[0] . $color[0], $color[1] . $color[1], $color[2] . $color[2] );
 	} else {
+		$default                 = \Go\Core\get_default_color_scheme();
+		$avaliable_color_schemes = get_available_color_schemes();
+		if ( isset( $avaliable_color_schemes[ $default ] ) && isset( $avaliable_color_schemes[ $default ]['primary'] ) ) {
+			$default = $avaliable_color_schemes[ $default ]['primary'];
+		}
 		return $default;
 	}
 

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -288,7 +288,7 @@ function get_copyright_kses_html() {
  *
  * @return string|array|bool A string with the RGB value or an array containing the HSL values.
  */
-function get_palette_color( $color, $format = 'RBG' ) {
+function get_palette_color( $color, $format = 'RGB' ) {
 	$default         = \Go\Core\get_default_color_scheme();
 	$color_scheme    = get_theme_mod( 'color_scheme', $default );
 	$override_colors = array(
@@ -322,8 +322,8 @@ function get_palette_color( $color, $format = 'RBG' ) {
 			return hex_to_hsl( $the_color );
 		}
 
-		if ( 'RBG' === $format ) {
-			return hex_to_rbg( $the_color );
+		if ( 'RGB' === $format ) {
+			return hex_to_rgb( $the_color );
 		}
 	}
 
@@ -338,7 +338,7 @@ function get_palette_color( $color, $format = 'RBG' ) {
  *
  * @return string|array|bool A string with the RGB value or an array containing the HSL values.
  */
-function get_default_palette_color( $color, $format = 'RBG' ) {
+function get_default_palette_color( $color, $format = 'RGB' ) {
 	$default                 = \Go\Core\get_default_color_scheme();
 	$color_scheme            = get_theme_mod( 'color_scheme', $default );
 	$avaliable_color_schemes = get_available_color_schemes();
@@ -371,7 +371,7 @@ function get_default_palette_color( $color, $format = 'RBG' ) {
  *
  * @return string
  */
-function hex_to_rbg( $color, $opacity = false ) {
+function hex_to_rgb( $color, $opacity = false ) {
 
 	if ( empty( $color ) ) {
 		return false;

--- a/includes/title-meta.php
+++ b/includes/title-meta.php
@@ -24,19 +24,34 @@ function setup() {
 		'post',
 		'hide_page_title',
 		array(
-			'sanitize_callback' => function( $status ) {
-				$status = strtolower( trim( $status ) );
-				if ( ! in_array( $status, array( 'enabled', 'disabled' ), true ) ) {
-					$status = '';
-				}
-				return $status;
-			},
+			'sanitize_callback' => $n( 'hide_page_title_callback' ),
 			'type'              => 'string',
 			'description'       => __( 'Hide Page Title.', 'go' ),
 			'show_in_rest'      => true,
 			'single'            => true,
 		)
 	);
+
+}
+
+/**
+ * Hide page title meta callback
+ *
+ * @param  string $status Hide page title status (eg: enable, disabled).
+ *
+ * @return string Whether or not the page title should be enabled or not.
+ */
+function hide_page_title_callback( $status ) {
+
+	$status = strtolower( trim( $status ) );
+
+	if ( ! in_array( $status, array( 'enabled', 'disabled' ), true ) ) {
+
+		$status = '';
+
+	}
+
+	return $status;
 
 }
 


### PR DESCRIPTION
The gradient control within Gutenberg requires `rgb` formatting, instead of `hsl`. This PR resolves that. 

Before:
![gradients-not](https://user-images.githubusercontent.com/1813435/83908375-05c31e00-a735-11ea-8934-10ece7ab4bd8.gif)

After:
![gradient-fixed](https://user-images.githubusercontent.com/1813435/83908389-0b206880-a735-11ea-92fd-107d63035c50.gif)
