### PR TITLE
Apply :root to better prevent Gutenberg overriding theme colors. 

### DIFF
--- a/.dev/assets/shared/css/utilities/colors.css
+++ b/.dev/assets/shared/css/utilities/colors.css
@@ -15,39 +15,43 @@
 	}
 }
 
-.has-primary-color {
-	color: var(--go--color--primary);
-}
+:root {
 
-.has-secondary-background-color {
-	background-color: var(--go--color--secondary);
-}
+	& .has-primary-color {
+		color: var(--go--color--primary);
+	}
 
-.has-secondary-color {
-	color: var(--go--color--secondary);
-}
+	& .has-secondary-background-color {
+		background-color: var(--go--color--secondary);
+	}
 
-.has-tertiary-background-color {
-	background-color: var(--go--color--tertiary);
+	& .has-secondary-color {
+		color: var(--go--color--secondary);
+	}
 
-	&,
-	& a:not(.wp-block-button__link) {
-		color: var(--go-heading--color--text);
+	& .has-tertiary-background-color {
+		background-color: var(--go--color--tertiary);
+
+		&,
+		& a:not(.wp-block-button__link) {
+			color: var(--go-heading--color--text);
+		}
+	}
+
+	& .has-tertiary-color {
+		color: var(--go--color--tertiary);
+	}
+
+	& .has-quaternary-background-color {
+		background-color: var(--go--color--white);
+	}
+
+	& .has-quaternary-color {
+		color: var(--go--color--white);
+
+		&.wp-block-button__link {
+			color: var(--go--color--white) !important;
+		}
 	}
 }
 
-.has-tertiary-color {
-	color: var(--go--color--tertiary);
-}
-
-.has-quaternary-background-color {
-	background-color: var(--go--color--white);
-}
-
-.has-quaternary-color {
-	color: var(--go--color--white);
-
-	&.wp-block-button__link {
-		color: var(--go--color--white) !important;
-	}
-}

--- a/.dev/assets/shared/css/utilities/colors.css
+++ b/.dev/assets/shared/css/utilities/colors.css
@@ -1,21 +1,21 @@
 /*! Color Utility Classes */
-.has-primary-background-color {
-	background-color: var(--go--color--primary);
-
-	&,
-	& label,
-	& h1:not([class*="color"]),
-	& h2:not([class*="color"]),
-	& h3:not([class*="color"]),
-	& h4:not([class*="color"]),
-	& h5:not([class*="color"]),
-	& h6:not([class*="color"]),
-	& a:not(.wp-block-button__link) {
-		color: var(--go--color--white);
-	}
-}
-
 :root {
+
+	& .has-primary-background-color {
+		background-color: var(--go--color--primary);
+
+		&,
+		& label,
+		& h1:not([class*="color"]),
+		& h2:not([class*="color"]),
+		& h3:not([class*="color"]),
+		& h4:not([class*="color"]),
+		& h5:not([class*="color"]),
+		& h6:not([class*="color"]),
+		& a:not(.wp-block-button__link) {
+			color: var(--go--color--white);
+		}
+	}
 
 	& .has-primary-color {
 		color: var(--go--color--primary);


### PR DESCRIPTION
Gutenberg's styling applies a background color of `#000` automatically to the cover block, even if there's no background image added (instead featuring a background color). TwentyTwenty loads the colors within `:root`, so this PR does the same, to prevent this conflict from happening with the cover block. 

Before: 
<img width="1521" alt="Screen Shot 2020-06-29 at 11 59 06 AM" src="https://user-images.githubusercontent.com/1813435/86028508-f49dc200-b9ff-11ea-99e2-5cf1ed3266d6.png">

After: 
<img width="1554" alt="Screen Shot 2020-06-29 at 11 58 54 AM" src="https://user-images.githubusercontent.com/1813435/86028514-f5ceef00-b9ff-11ea-97d0-cee412e4a0e1.png">
