### PR TITLE
Update post meta tags wrapper CSS

### DIFF
--- a/.dev/assets/shared/css/layout/post.css
+++ b/.dev/assets/shared/css/layout/post.css
@@ -13,7 +13,8 @@
 
 /*! Post Meta */
 .post__meta--wrapper {
-	margin-top: 2rem;
+	margin: 0 auto;
+	max-width: var(--go--max-width);
 }
 
 .post__meta {

--- a/.dev/assets/shared/css/layout/post.css
+++ b/.dev/assets/shared/css/layout/post.css
@@ -13,7 +13,7 @@
 
 /*! Post Meta */
 .post__meta--wrapper {
-	margin: 0 auto;
+	margin: 2rem auto 0;
 	max-width: var(--go--max-width);
 }
 
@@ -87,7 +87,6 @@
 
 .post__meta--single-bottom {
 	margin-bottom: var(--go--spacing--vertical--lg);
-	margin-top: 0;
 
 	& .post-tags {
 		margin-bottom: 0;


### PR DESCRIPTION
Resolves #547 

The top `2rem` margin was removed because it was being overridden in another style definition and had no effect.

![image](https://user-images.githubusercontent.com/5321364/87342162-cb5d5580-c518-11ea-982c-63807bb78c2b.png)