### PR TITLE
Update styles for Cover block positioning in WordPress 5.5

### DIFF
--- a/.dev/assets/shared/css/blocks/cover.css
+++ b/.dev/assets/shared/css/blocks/cover.css
@@ -17,6 +17,17 @@
 	& ol {
 		padding-left: 0;
 	}
+
+	&:not(.is-position-center-center) {
+
+		& .wp-block-cover__inner-container {
+			padding: calc(var(--go--spacing--vertical) * 0.5) var(--go--spacing--vertical);
+
+			@media (--medium) {
+				padding: calc(var(--go--spacing--vertical) * 1.5) calc(var(--go--spacing--vertical) * 2);
+			}
+		}
+	}
 }
 
 .wp-block-cover__inner-container {


### PR DESCRIPTION
Updates styles to support the Cover block positioning available in WordPress 5.5

![cover](https://user-images.githubusercontent.com/1813435/88576322-417eb380-d013-11ea-99a2-8272d6d03e18.gif)
