### PR TITLE
Fix: Group block's custom padding was not reflected in the editor

### DIFF
--- a/.dev/assets/shared/css/blocks/group.css
+++ b/.dev/assets/shared/css/blocks/group.css
@@ -2,15 +2,18 @@
 .wp-block-group {
 
 	&.has-background {
-		padding: var(--go--spacing--vertical) calc(var(--go--spacing--vertical) * 1.3);
 
-		@media (--medium) {
-			padding: calc(var(--go--spacing--vertical--lg) * 0.2) calc(var(--go--spacing--vertical--lg) * 0.25);
-		}
+		&:not([class*="padding"]) {
+			padding: var(--go--spacing--vertical) calc(var(--go--spacing--vertical) * 1.3);
 
-		&.alignwide,
-		&.alignfull {
-			padding: var(--go--spacing--vertical--lg);
+			@media (--medium) {
+				padding: calc(var(--go--spacing--vertical--lg) * 0.2) calc(var(--go--spacing--vertical--lg) * 0.25);
+			}
+
+			&.alignwide,
+			&.alignfull {
+				padding: var(--go--spacing--vertical--lg);
+			}
 		}
 
 		&.alignfull + .has-background.alignfull:not(.wp-block-gallery) {

--- a/.dev/assets/shared/css/editor/group.css
+++ b/.dev/assets/shared/css/editor/group.css
@@ -2,7 +2,7 @@
 .wp-block[data-type="core/group"][data-align="wide"],
 .wp-block[data-type="core/group"][data-align="full"] {
 
-	& .wp-block-group.has-background {
+	& .wp-block-group.has-background:not([class*="padding"]) {
 		padding: var(--go--spacing--vertical--lg);
 	}
 }
@@ -10,7 +10,7 @@
 .wp-block[data-align="wide"],
 .wp-block[data-align="full"] {
 
-	& .wp-block-group.has-background {
+	& .wp-block-group.has-background:not([class*="padding"]) {
 		padding: var(--go--spacing--vertical--lg);
 	}
 }


### PR DESCRIPTION
Fixes an issue where Group block's custom padding was not reflected in the editor. To resolve this, Go's padding only gets applied if `:not([class*="padding"])` exists on the block. Originally discovered by @jasonlemay.