### PR TITLE
Exclude the CoBlocks Form block .custom-color label

### DIFF
--- a/.dev/assets/shared/css/style-editor.css
+++ b/.dev/assets/shared/css/style-editor.css
@@ -164,7 +164,7 @@
 }
 
 .wp-block-search__label .rich-text,
-label:not(.components-toggle-control__label):not(.components-base-control__label) {
+label:not(.components-toggle-control__label):not(.components-base-control__label):not(.custom-color) {
 	color: var(--go-label--color--text, var(--go-heading--color--text));
 	font-family: var(--go-label--font-family, var(--go-navigation--font-family));
 	font-size: var(--go-label--font-size);

--- a/.dev/assets/shared/css/style-editor.css
+++ b/.dev/assets/shared/css/style-editor.css
@@ -164,7 +164,7 @@
 }
 
 .wp-block-search__label .rich-text,
-label:not(.components-toggle-control__label):not(.components-base-control__label):not(.custom-color) {
+label:not(.components-toggle-control__label):not(.components-base-control__label):not(.has-text-color) {
 	color: var(--go-label--color--text, var(--go-heading--color--text));
 	font-family: var(--go-label--font-family, var(--go-navigation--font-family));
 	font-size: var(--go-label--font-size);


### PR DESCRIPTION
**Related:** https://github.com/godaddy-wordpress/coblocks/pull/1646

Form labels will not change colors without the changes made here. They will work with other themes (Unless other themes are also overriding the label colors in the editor)