### PR TITLE
Menu hover/click settings toggle

### DIFF
--- a/.dev/assets/shared/css/header/sub-menu.css
+++ b/.dev/assets/shared/css/header/sub-menu.css
@@ -50,6 +50,17 @@
 				left: 50%;
 			}
 		}
+
+		/* Spacer to fix menu hovers */
+		&::after {
+			bottom: 100%;
+			content: "";
+			height: 1.75rem;
+			left: 0;
+			position: absolute;
+			right: 0;
+			width: 100%;
+		}
 	}
 
 	/* All other submenus */
@@ -126,6 +137,7 @@
 
 	& svg {
 		transform: rotate(180deg);
+		z-index: 9999;
 	}
 }
 

--- a/.dev/assets/shared/js/frontend/components/primary-menu.js
+++ b/.dev/assets/shared/js/frontend/components/primary-menu.js
@@ -10,7 +10,7 @@ const init = () => {
 			target: '#header__navigation',
 			toggle: '#nav-toggle',
 			// eslint-disable-next-line
-			sub_menu_open: 'click'
+			sub_menu_open: goFrontend.openMenuOnHover ? 'hover' : 'click'
 		} );
 	}
 

--- a/.dev/assets/shared/js/frontend/vendor/responsive-nav.js
+++ b/.dev/assets/shared/js/frontend/vendor/responsive-nav.js
@@ -220,10 +220,12 @@
 		}; // listener_close_open_menus()
 
 		function menu_sub_close( open_item ) {
-			open_item.classList.remove('submenu-is-open');
-			open_item.parentNode.classList.remove('child-has-focus');
+			if ( open_item && open_item.classList ) {
+				open_item.classList.remove('submenu-is-open');
+				open_item.parentNode.classList.remove('child-has-focus');
+			}
 
-			if ( open_item.parentNode.querySelector( '.sub-menu' ) ) {
+			if ( open_item && open_item.parentNode && open_item.parentNode.querySelector( '.sub-menu' ) ) {
 				open_item.parentNode.querySelector( '.sub-menu' ).setAttribute( 'aria-hidden', 'true' );
 			}
 		}; // menu_sub_close()
@@ -376,6 +378,29 @@
 				menu.classList.add( 'uses-click' );
 			} else if ( sub_menu_acion !== 'click' ) {
 				if ( get_screen_size( 'has-full-nav' ) ) {
+					menu_items_with_children[i].addEventListener( 'mouseover', listener_submenu_focus );
+					menu_items_with_children[i].addEventListener( 'mouseout', function() {
+						var closeParentMenu = setTimeout( function() {
+							var open_menus = menu.querySelectorAll('.submenu-is-open');
+							var open_menus_count = open_menus.length;
+							var opn;
+
+							// We were getting some errors, so let's add in a checkpoint
+							if ( open_menus_count ) {
+
+								// Loop through all the open menus and close them
+								for ( opn = 0; opn < open_menus.length; opn = opn + 1 ) {
+
+									var open_menus = menu.querySelectorAll('.submenu-is-open');
+
+									menu_sub_close( open_menus[opn] );
+
+								} // for
+
+							}
+
+						}, 200 );
+					} );
 					menu_items_with_children[i].addEventListener( 'focusin', listener_submenu_focus );
 				} // if
 			} // if

--- a/.dev/assets/shared/js/frontend/vendor/responsive-nav.js
+++ b/.dev/assets/shared/js/frontend/vendor/responsive-nav.js
@@ -7,7 +7,7 @@
 
 		'target'		:	'#primary-nav',      // the selector of the nav menu <ul>
 		'toggle'		:	'#js-menu-toggle',   // the ID of the link you're using to open/close the small screen menu
-		'sub_menu_open'	:	'hover'              // "click" is the other option
+		'sub_menu_open'	:	'hover'
 
 	}, function() {
 
@@ -98,9 +98,20 @@
 			currentTarget = e.currentTarget;
 			target = e.target;
 
+			console.log( 'Before' );
+			console.log( currentTarget );
+			console.log( target );
+			console.log( '----------' );
+
 			if ( target.tagName === 'svg' || target.tagName === 'path' ) {
+				console.log( 'Yes, the target is an SVG' );
 				target = currentTarget.closest( '.menu-item > a' );
 			}
+
+			console.log( 'After' );
+			console.log( currentTarget );
+			console.log( target );
+			console.log( '----------' );
 
 			if ( target.getAttribute( 'aria-haspopup' ) ) {
 				// Stop links from firing
@@ -267,11 +278,11 @@
 
 				// Loop through all submenus and bind events when needed
 				for ( i = 0; i < menu_items_with_children_count; i = i + 1 ) {
-					if ( sub_menu_acion !== 'click' ) {
-						menu_items_with_children[i].addEventListener( 'click', listener_submenu_click );
-						menu_items_with_children[i].removeEventListener( 'focusin', listener_submenu_focus );
-						menu.classList.add( 'uses-click' );
+					var svgElements = menu_items_with_children[i].querySelectorAll( 'svg' );
+					for ( var q = 0; q < svgElements.length; q = q + 1 ) {
+						svgElements[q].addEventListener( 'click', listener_submenu_click );
 					}
+					menu_items_with_children[i].removeEventListener( 'focusin', listener_submenu_focus );
 				} // for
 
 				// Bind the event
@@ -375,33 +386,34 @@
 
 				}
 
-				menu.classList.add( 'uses-click' );
+				menu.classList.add( sub_menu_acion === 'click' ? 'uses-click' : 'uses-hover' );
 			} else if ( sub_menu_acion !== 'click' ) {
 				if ( get_screen_size( 'has-full-nav' ) ) {
 					menu_items_with_children[i].addEventListener( 'mouseover', listener_submenu_focus );
 					menu_items_with_children[i].addEventListener( 'mouseout', function() {
-						var closeParentMenu = setTimeout( function() {
-							var open_menus = menu.querySelectorAll('.submenu-is-open');
-							var open_menus_count = open_menus.length;
-							var opn;
+						var open_menus = menu.querySelectorAll( '.submenu-is-open' );
+						var open_menus_count = open_menus.length;
+						var opn;
 
-							// We were getting some errors, so let's add in a checkpoint
-							if ( open_menus_count ) {
+						// We were getting some errors, so let's add in a checkpoint
+						if ( open_menus_count ) {
 
-								// Loop through all the open menus and close them
-								for ( opn = 0; opn < open_menus.length; opn = opn + 1 ) {
+							// Loop through all the open menus and close them
+							for ( opn = 0; opn < open_menus_count; opn = opn + 1 ) {
 
-									var open_menus = menu.querySelectorAll('.submenu-is-open');
+								menu_sub_close( open_menus[opn] );
 
-									menu_sub_close( open_menus[opn] );
+							} // for
 
-								} // for
-
-							}
-
-						}, 200 );
+						}
 					} );
 					menu_items_with_children[i].addEventListener( 'focusin', listener_submenu_focus );
+					menu_items_with_children[i].querySelectorAll( '.sub-menu' ).forEach( submenu => {
+						submenu.addEventListener( 'mouseover', event => {
+							submenu.parentElement.classList.add( 'child-has-focus' );
+							submenu.previousElementSibling.classList.add( 'submenu-is-open' );
+						}, false );
+					} );
 				} // if
 			} // if
 		} // for

--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -557,7 +557,7 @@ class Test_Core extends WP_UnitTestCase {
 
 		global $wp_scripts;
 
-		$this->assertEquals( 'var goFrontend = {"openMenuOnHover":false};', $wp_scripts->registered['go-frontend']->extra['data'] );
+		$this->assertEquals( 'var goFrontend = {"openMenuOnHover":""};', $wp_scripts->registered['go-frontend']->extra['data'] );
 
 	}
 

--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -557,7 +557,7 @@ class Test_Core extends WP_UnitTestCase {
 
 		global $wp_scripts;
 
-		$this->assertEquals( 'var goFrontend = {"openMenuOnHover":""};', $wp_scripts->registered['go-frontend']->extra['data'] );
+		$this->assertEquals( 'var goFrontend = {"openMenuOnHover":"1"};', $wp_scripts->registered['go-frontend']->extra['data'] );
 
 	}
 

--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -557,7 +557,7 @@ class Test_Core extends WP_UnitTestCase {
 
 		global $wp_scripts;
 
-		$this->assertEquals( 'var GoText = {"searchLabel":"Expand search field"};', $wp_scripts->registered['go-frontend']->extra['data'] );
+		$this->assertEquals( 'var goFrontend = {"openMenuOnHover":false};', $wp_scripts->registered['go-frontend']->extra['data'] );
 
 	}
 

--- a/.dev/tests/php/test-customizer.php
+++ b/.dev/tests/php/test-customizer.php
@@ -138,6 +138,19 @@ class Test_Customizer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test register_menu_controls is hooked correctly
+	 */
+	function test_hooked_register_menu_controls() {
+
+		$this->assertEquals(
+			10,
+			has_action( 'customize_register', 'Go\Customizer\register_menu_controls' ),
+			'customize_register is not attached to Go\Customizer\register_menu_controls. It might also have the wrong priority (validated priority: 10)'
+		);
+
+	}
+
+	/**
 	 * Test customize_preview_init is hooked correctly to customize_preview_init
 	 */
 	function test_hooked_customize_preview_init() {
@@ -973,6 +986,17 @@ class Test_Customizer extends WP_UnitTestCase {
 		}
 
 		$this->assertTrue( true );
+
+	}
+
+	/**
+	 * Test the register_menu_controls section is registered
+	 */
+	function test_register_menu_controls_menus_section() {
+
+		Go\Customizer\register_social_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_section( 'go_menu_behavior' ) );
 
 	}
 

--- a/.dev/tests/php/test-customizer.php
+++ b/.dev/tests/php/test-customizer.php
@@ -994,7 +994,7 @@ class Test_Customizer extends WP_UnitTestCase {
 	 */
 	function test_register_menu_controls_menus_section() {
 
-		Go\Customizer\register_social_controls( $GLOBALS['wp_customize'] );
+		Go\Customizer\register_menu_controls( $GLOBALS['wp_customize'] );
 
 		$this->assertNotNull( $GLOBALS['wp_customize']->get_section( 'go_menu_behavior' ) );
 

--- a/includes/core.php
+++ b/includes/core.php
@@ -390,9 +390,9 @@ function scripts() {
 
 	wp_localize_script(
 		'go-frontend',
-		'GoText',
+		'goFrontend',
 		array(
-			'searchLabel' => esc_html__( 'Expand search field', 'go' ),
+			'openMenuOnHover' => (bool) get_theme_mod( 'open_menu_on_hover', false ),
 		)
 	);
 

--- a/includes/core.php
+++ b/includes/core.php
@@ -395,7 +395,7 @@ function scripts() {
 		'go-frontend',
 		'goFrontend',
 		array(
-			'openMenuOnHover' => (bool) get_theme_mod( 'open_menu_on_hover', false ),
+			'openMenuOnHover' => (bool) get_theme_mod( 'open_menu_on_hover', true ),
 		)
 	);
 

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -28,6 +28,7 @@ function setup() {
 	add_action( 'customize_register', $n( 'register_header_controls' ) );
 	add_action( 'customize_register', $n( 'register_footer_controls' ) );
 	add_action( 'customize_register', $n( 'register_social_controls' ) );
+	add_action( 'customize_register', $n( 'register_menu_controls' ) );
 	add_action( 'customize_register', $n( 'rename_panels' ) );
 	add_action( 'customize_preview_init', $n( 'customize_preview_init' ) );
 	add_action( 'customize_controls_enqueue_scripts', $n( 'customize_preview_init' ) );
@@ -935,6 +936,45 @@ function register_social_controls( \WP_Customize_Manager $wp_customize ) {
 			)
 		)
 	);
+}
+
+/**
+ * Register the menu within Customize.
+ *
+ * @param \WP_Customize_Manager $wp_customize The customize manager object.
+ *
+ * @return void
+ */
+function register_menu_controls( \WP_Customize_Manager $wp_customize ) {
+
+	$wp_customize->add_section(
+		'menu_behavior',
+		array(
+			'title' => __( 'Menu Behavior', 'go' ),
+			'panel' => 'nav_menus',
+		)
+	);
+
+	$wp_customize->add_setting(
+		'open_menu_on_hover',
+		array(
+			'capability'        => 'edit_theme_options',
+			'default'           => false,
+			'sanitize_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		'open_menu_on_hover',
+		array(
+			'label'    => __( 'Show sub menus on hover.', 'go' ),
+			'description' => esc_html__( 'Show sub menu items on hover.', 'go' ),
+			'section'  => 'menu_behavior',
+			'settings' => 'open_menu_on_hover',
+			'type'     => 'checkbox',
+		)
+	);
+
 }
 
 /**

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -948,7 +948,7 @@ function register_social_controls( \WP_Customize_Manager $wp_customize ) {
 function register_menu_controls( \WP_Customize_Manager $wp_customize ) {
 
 	$wp_customize->add_section(
-		'menu_behavior',
+		'go_menu_behavior',
 		array(
 			'title' => __( 'Menu Behavior', 'go' ),
 			'panel' => 'nav_menus',
@@ -969,7 +969,7 @@ function register_menu_controls( \WP_Customize_Manager $wp_customize ) {
 		array(
 			'label'       => __( 'Show sub menus on hover.', 'go' ),
 			'description' => esc_html__( 'Show sub menu items on hover.', 'go' ),
-			'section'     => 'menu_behavior',
+			'section'     => 'go_menu_behavior',
 			'settings'    => 'open_menu_on_hover',
 			'type'        => 'checkbox',
 		)

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -959,7 +959,7 @@ function register_menu_controls( \WP_Customize_Manager $wp_customize ) {
 		'open_menu_on_hover',
 		array(
 			'capability'        => 'edit_theme_options',
-			'default'           => false,
+			'default'           => true,
 			'sanitize_callback' => 'absint',
 		)
 	);

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -967,11 +967,11 @@ function register_menu_controls( \WP_Customize_Manager $wp_customize ) {
 	$wp_customize->add_control(
 		'open_menu_on_hover',
 		array(
-			'label'    => __( 'Show sub menus on hover.', 'go' ),
+			'label'       => __( 'Show sub menus on hover.', 'go' ),
 			'description' => esc_html__( 'Show sub menu items on hover.', 'go' ),
-			'section'  => 'menu_behavior',
-			'settings' => 'open_menu_on_hover',
-			'type'     => 'checkbox',
+			'section'     => 'menu_behavior',
+			'settings'    => 'open_menu_on_hover',
+			'type'        => 'checkbox',
 		)
 	);
 


### PR DESCRIPTION
Resolves #529

This PR introduces a new customizer setting `Menus > Menu Behavior > Show sub menus on hover.`. This is `false` (unchecked) by default, so sites that are currently using the theme will see no changes. New users, or those who want to show submenus on hover can enable this setting.

- [x] Unit tests have been added to maintain %100 coverage.
https://8245-196281488-gh.circle-artifacts.com/0/phpunit-coverage/phpunit/html/index.html

### Demo
![menu-hover](https://user-images.githubusercontent.com/5321364/91596443-d33f5080-e932-11ea-8f97-3926dd52eb25.gif)
