### PR TITLE
Add the ability to toggle post excerpt length on the blog roll

### DIFF
--- a/.dev/tests/php/test-customizer.php
+++ b/.dev/tests/php/test-customizer.php
@@ -547,6 +547,28 @@ class Test_Customizer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the blog_excerpt setting is registered
+	 */
+	function test_register_global_controls_blog_excerpt_setting() {
+
+		Go\Customizer\register_global_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_setting( 'blog_excerpt' ) );
+
+	}
+
+	/**
+	 * Test the blog_excerpt_checkbox control is registered
+	 */
+	function test_register_global_controls_blog_excerpt_checkbox_control() {
+
+		Go\Customizer\register_global_controls( $GLOBALS['wp_customize'] );
+
+		$this->assertNotNull( $GLOBALS['wp_customize']->get_control( 'blog_excerpt_checkbox' ) );
+
+	}
+
+	/**
 	 * Test the copyright setting is registered
 	 */
 	function test_register_global_controls_copyright_setting() {

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -372,7 +372,6 @@ function register_global_controls( \WP_Customize_Manager $wp_customize ) {
 		'blog_excerpt',
 		array(
 			'default'           => false,
-			'transport'         => 'postMessage',
 			'sanitize_callback' => 'absint',
 		)
 	);

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -369,6 +369,26 @@ function register_global_controls( \WP_Customize_Manager $wp_customize ) {
 	);
 
 	$wp_customize->add_setting(
+		'blog_excerpt',
+		array(
+			'default'           => false,
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		'blog_excerpt_checkbox',
+		array(
+			'label'       => esc_html__( 'Blog Excerpt', 'go' ),
+			'description' => esc_html__( 'Use post excerpts on the blog page.', 'go' ),
+			'section'     => 'go_site_settings',
+			'settings'    => 'blog_excerpt',
+			'type'        => 'checkbox',
+		)
+	);
+
+	$wp_customize->add_setting(
 		'copyright',
 		array(
 			'default'           => \Go\Core\get_default_copyright(),

--- a/partials/content.php
+++ b/partials/content.php
@@ -34,7 +34,7 @@
 
 		<div class="content-area entry-content">
 			<?php
-			if ( is_search() ) {
+			if ( is_search() || get_theme_mod( 'blog_excerpt', false ) ) {
 				the_excerpt();
 			} else {
 				the_content();


### PR DESCRIPTION
Adds a new checkbox in the site settings panel in the customizer to toggle between full length posts and excerpts, on the blog list. Defaults value is `false` so current users will not see any changes.

- [x] Unit Tests included

#### Post Excerpts
![image](https://user-images.githubusercontent.com/5321364/91664050-91411680-eaba-11ea-955e-b4836be06868.png)

#### Default
![image](https://user-images.githubusercontent.com/5321364/91664095-eb41dc00-eaba-11ea-870d-1f02dc73f48e.png)
