### PR TITLE
Fix radio group error notice visibility

### DIFF
--- a/.dev/assets/shared/css/elements/forms.css
+++ b/.dev/assets/shared/css/elements/forms.css
@@ -42,7 +42,9 @@ input[type="color"] {
 
 input[type="radio"],
 input[type="checkbox"] {
+	height: 19px;
 	opacity: 0;
+	width: 20px;
 }
 
 .coblocks-field {

--- a/.dev/assets/shared/css/elements/forms.css
+++ b/.dev/assets/shared/css/elements/forms.css
@@ -42,7 +42,7 @@ input[type="color"] {
 
 input[type="radio"],
 input[type="checkbox"] {
-	appearance: none;
+	opacity: 0;
 }
 
 .coblocks-field {


### PR DESCRIPTION
Related: https://github.com/godaddy-wordpress/coblocks/pull/1643

Radio group error notices weren't displaying because the radio buttons are set to `appearance: none;`.

Setting them to `opacity: 0;` lets the error notices to display properly.

![form-radio-error](https://user-images.githubusercontent.com/5321364/92159050-c622d580-edfa-11ea-94c9-5f061676f69d.gif)