### PR TITLE
Add underline to WooCommerce product title on hover

### DIFF
--- a/.dev/assets/shared/css/woocommerce/product.scss
+++ b/.dev/assets/shared/css/woocommerce/product.scss
@@ -20,6 +20,10 @@
 	}
 }
 
+.woocommerce ul.products li.product:hover h2.woocommerce-loop-product__title {
+	text-decoration: underline;
+}
+
 .woocommerce div.product .woocommerce-tabs ul.tabs li.active {
 	background: transparent;
 }


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/5321364/98725615-5cc3c380-2363-11eb-94a2-c2244a7321c9.png" width="350" />