### PR TITLE
Fix submenu hover regression introduced in 1.3.7

### DIFF
--- a/.dev/assets/shared/css/header/sub-menu.scss
+++ b/.dev/assets/shared/css/header/sub-menu.scss
@@ -140,9 +140,3 @@
 		z-index: 9999;
 	}
 }
-
-.sub-menu[aria-hidden="true"] {
-	display: none;
-	opacity: 0;
-	visibility: hidden;
-}

--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -374,7 +374,7 @@ class Test_Core extends WP_UnitTestCase {
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
 		$GLOBALS['wp_customize']->setup_theme();
 
-		$expected = 'https://fonts.googleapis.com/css?family=Crimson Text:400,400i,700,700i|Nunito Sans:400,400i,600,700|Heebo:400,800|Fira Code:400,400i,700|Montserrat:400,700|Trocchi:400,600|Noto Sans:400,400i,700|Source Code Pro:400,700|Work Sans:300,700|Karla:400,400i,700|Quicksand:400,600|Poppins:700&subset=latin,latin-ext';
+		$expected = 'https://fonts.googleapis.com/css?family=Crimson Text:400,400i,700,700i|Nunito Sans:400,400i,600,700|Heebo:400,800|Fira Code:400,400i,700|Montserrat:400,700|Trocchi:400,600|Noto Sans:400,400i,700|Source Code Pro:400,700|Work Sans:300,700|Karla:400,400i,700|Poppins:600|Quicksand:400,600&subset=latin,latin-ext';
 
 		$this->assertEquals( urldecode( $expected ), urldecode( Go\Core\fonts_url() ) );
 

--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -16,6 +16,8 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		parent::tearDown();
 
+		delete_option( 'woocommerce_shop_page_id' );
+
 	}
 
 	/**

--- a/comments.php
+++ b/comments.php
@@ -63,7 +63,9 @@ if ( post_password_required() ) {
 				<div class="nav-next"><?php next_comments_link( esc_html_e( 'Newer Comments &rarr;', 'go' ) ); ?></div>
 			</nav>
 			<?php endif; ?>
+
 			<?php
+
 			/*
 			 * If there are no comments and comments are closed, let's leave a note.
 			 * But we only want the note on posts and pages that had comments in the first place.

--- a/comments.php
+++ b/comments.php
@@ -65,7 +65,6 @@ if ( post_password_required() ) {
 			<?php endif; ?>
 
 			<?php
-
 			/*
 			 * If there are no comments and comments are closed, let's leave a note.
 			 * But we only want the note on posts and pages that had comments in the first place.

--- a/includes/pluggable.php
+++ b/includes/pluggable.php
@@ -79,7 +79,6 @@ if ( ! function_exists( 'go_comment' ) ) :
 				</div><!-- .reply -->
 			</article><!-- #comment-## -->
 				<?php
-				break;
 
 		endswitch; // end comment_type check.
 	}


### PR DESCRIPTION
After transitioning over from `css` to `scss` this small bit of CSS code was included. Previously, this code existed [here](https://github.com/godaddy-wordpress/go/blob/4d39669d5cd2798f2b808fa7045303e8e8be16ce/.dev/assets/shared/css/header/sub-menu.css#L144-L148), but had no effect since it was invalid css. When it got copied over, and the invalid css was fixed, it caused open menus to be hidden.