### PR TITLE
Hide page title toggle when customizer option is unchecked

### DIFF
--- a/.dev/assets/admin/js/block-filters.js
+++ b/.dev/assets/admin/js/block-filters.js
@@ -31,7 +31,7 @@ function GoPageTitleToggle( { isEnabled, onChange } ) {
 		} );
 	} );
 
-	if ( 'page' !== wp.data.select('core/editor').getCurrentPostType() ) {
+	if ( 'page' !== wp.data.select('core/editor').getCurrentPostType() || ! GoBlockFilters.showPageTitles ) {
 
 		return null;
 

--- a/includes/core.php
+++ b/includes/core.php
@@ -353,7 +353,8 @@ function block_editor_assets() {
 		'go-block-filters',
 		'GoBlockFilters',
 		array(
-			'inlineStyles' => str_replace( ':root', '.editor-styles-wrapper', $styles ),
+			'inlineStyles'   => str_replace( ':root', '.editor-styles-wrapper', $styles ),
+			'showPageTitles' => (bool) get_theme_mod( 'page_titles', true ),
 		)
 	);
 


### PR DESCRIPTION
##### Note:
- Visual regression tests are failing due to a minor tweak in spacing in separate PR.

### Customizer 'Page Titles' option checked
<img src="https://user-images.githubusercontent.com/5321364/103805332-6c891c80-5021-11eb-8b21-93fae17b6ab5.png" width="300" />

### Customizer 'Page Titles' option unchecked
<img src="https://user-images.githubusercontent.com/5321364/103805369-7874de80-5021-11eb-8122-c371a7dc8788.png" width="300" />
