### PR TITLE
Fix Go styles resulting in alignment bug

### DIFF
--- a/.dev/assets/shared/css/editor/horizontal-rhythm.scss
+++ b/.dev/assets/shared/css/editor/horizontal-rhythm.scss
@@ -1,7 +1,7 @@
 .wp-block {
 	max-width: var(--go--max-width);
 
-	.wp-block {
+	.wp-block:not(.wp-block-button) {
 		width: 100%;
 	}
 


### PR DESCRIPTION
Specific Go styles are resulting in overridden alignment settings for the `core/buttons` block. 
Without this fix, alignment is correct on the front-end.


**Before fix**
![image](https://user-images.githubusercontent.com/30462574/106062731-70560f00-60b4-11eb-82a5-be70620ad0f8.png)


**With CSS fix in place.**
![image](https://user-images.githubusercontent.com/30462574/106062824-8fed3780-60b4-11eb-8729-35cf186bb3f0.png)

