### PR TITLE
Fix/modern woocommerce shipping radio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
           command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Install Composer packages
-          command: composer install
+          command: composer install -vvv
           working_directory: /tmp/wordpress/wp-content/themes/go
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
           command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Install Composer packages
-          command: composer install -vvv
+          command: composer install
           working_directory: /tmp/wordpress/wp-content/themes/go
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}

--- a/.dev/assets/design-styles/modern/css/style-modern.scss
+++ b/.dev/assets/design-styles/modern/css/style-modern.scss
@@ -8,6 +8,9 @@
 @import "blocks/carousel";
 @import "blocks/wc-button";
 
+// WooCommerce
+@import "woocommerce/checkout";
+
 @import "../../../shared/css/config/mixins";
 
 .site-title {

--- a/.dev/assets/design-styles/modern/css/style-modern.scss
+++ b/.dev/assets/design-styles/modern/css/style-modern.scss
@@ -92,7 +92,6 @@
 @include media(small) {
 	.woocommerce-page .woocommerce-shipping-methods label:before {
 		top: 0 !important;
-		display: none;
 	}
 }
 

--- a/.dev/assets/design-styles/modern/css/woocommerce/checkout.scss
+++ b/.dev/assets/design-styles/modern/css/woocommerce/checkout.scss
@@ -1,0 +1,10 @@
+.woocommerce-checkout {
+
+	#ship-to-different-address-checkbox {
+		top: -5px;
+	}
+
+	#wc-stripe-new-payment-method {
+		top: 3px;
+	}
+}

--- a/.dev/assets/design-styles/modern/css/woocommerce/checkout.scss
+++ b/.dev/assets/design-styles/modern/css/woocommerce/checkout.scss
@@ -7,4 +7,17 @@
 	#wc-stripe-new-payment-method {
 		top: 3px;
 	}
+
+	.wc_payment_methods {
+
+		li.wc_payment_method {
+
+			label[for^="payment_method_"] {
+
+				&::before {
+					top: 2px;
+				}
+			}
+		}
+	}
 }

--- a/.dev/assets/design-styles/traditional/css/style-traditional.scss
+++ b/.dev/assets/design-styles/traditional/css/style-traditional.scss
@@ -2,6 +2,8 @@
 @import "../../../shared/css/config/breakpoints";
 @import "../settings";
 
+@import "woocommerce/checkout";
+
 .wp-block-coblocks-food-item__attributes {
 	top: 0;
 }

--- a/.dev/assets/design-styles/traditional/css/woocommerce/checkout.scss
+++ b/.dev/assets/design-styles/traditional/css/woocommerce/checkout.scss
@@ -1,0 +1,6 @@
+.woocommerce-checkout {
+
+	#ship-to-different-address-checkbox {
+		margin-right: 0.5rem;
+	}
+}

--- a/.dev/assets/design-styles/trendy/css/style-trendy.scss
+++ b/.dev/assets/design-styles/trendy/css/style-trendy.scss
@@ -2,9 +2,12 @@
 @import "../../../shared/css/config/breakpoints";
 @import "../settings";
 
-//Blocks
+// Blocks
 @import "blocks/button";
 @import "blocks/carousel";
+
+// WooCommerce
+@import "woocommerce/checkout";
 
 body {
 	-webkit-font-smoothing: antialiased;

--- a/.dev/assets/design-styles/trendy/css/woocommerce/checkout.scss
+++ b/.dev/assets/design-styles/trendy/css/woocommerce/checkout.scss
@@ -1,0 +1,13 @@
+.woocommerce-checkout {
+
+	input[name="payment_method"] {
+
+		+ label {
+			padding-left: 2rem;
+
+			&::before {
+				top: 4px;
+			}
+		}
+	}
+}

--- a/.dev/assets/design-styles/welcoming/css/style-welcoming.scss
+++ b/.dev/assets/design-styles/welcoming/css/style-welcoming.scss
@@ -2,9 +2,12 @@
 @import "../../../shared/css/config/breakpoints";
 @import "../settings";
 
-//Blocks
+// Blocks
 @import "blocks/button";
 @import "blocks/carousel";
+
+// WooCommerce
+@import "woocommerce/checkout";
 
 html {
 	background-color: var(--go-header--color--background);

--- a/.dev/assets/design-styles/welcoming/css/woocommerce/checkout.scss
+++ b/.dev/assets/design-styles/welcoming/css/woocommerce/checkout.scss
@@ -1,9 +1,5 @@
 .woocommerce-checkout {
 
-	#ship-to-different-address-checkbox {
-		margin-right: 0.5rem;
-	}
-
 	.wc_payment_methods {
 
 		li.wc_payment_method {
@@ -11,7 +7,7 @@
 			label[for^="payment_method_"] {
 
 				&::before {
-					top: 5px;
+					top: 6px;
 				}
 			}
 		}

--- a/.dev/assets/shared/css/style-shared.scss
+++ b/.dev/assets/shared/css/style-shared.scss
@@ -60,6 +60,7 @@
 @import "woocommerce/account";
 @import "woocommerce/button";
 @import "woocommerce/cart";
+@import "woocommerce/checkout";
 @import "woocommerce/checkbox";
 @import "woocommerce/radio";
 @import "woocommerce/forms";

--- a/.dev/assets/shared/css/woocommerce/checkout.scss
+++ b/.dev/assets/shared/css/woocommerce/checkout.scss
@@ -18,4 +18,14 @@
 		top: 4px;
 		width: 20px !important;
 	}
+
+	.wc_payment_methods {
+
+		li.wc_payment_method {
+
+			label[for^="payment_method_"] {
+				padding-left: 2rem;
+			}
+		}
+	}
 }

--- a/.dev/assets/shared/css/woocommerce/checkout.scss
+++ b/.dev/assets/shared/css/woocommerce/checkout.scss
@@ -1,0 +1,21 @@
+.woocommerce-checkout {
+
+	.woocommerce-SavedPaymentMethods-saveNew {
+		padding: 0 1em 1em 1em !important;
+	}
+
+	input[name="wc-stripe-new-payment-method"] {
+		margin-right: 0.5em !important;
+	}
+
+	#ship-to-different-address-checkbox {
+		position: relative;
+		top: 3px;
+	}
+
+	#wc-stripe-new-payment-method {
+		position: relative;
+		top: 4px;
+		width: 20px !important;
+	}
+}

--- a/.dev/assets/shared/css/woocommerce/radio.scss
+++ b/.dev/assets/shared/css/woocommerce/radio.scss
@@ -22,6 +22,17 @@
 				top: 8px;
 			}
 		}
+
+		.payment_box {
+
+			label {
+				padding-left: unset;
+
+				&::before {
+					display: none;
+				}
+			}
+		}
 	}
 
 	.woocommerce-shipping-methods {


### PR DESCRIPTION
Resolves #645 

- [x] Introduce new WooCommerce override styles for certain templates.
- [x] Fix hidden radio and checkboxes on WooCommerce checkout.
- [x] Fix incorrect radio buttons on credit card checkout form.
- [x] Tweak spacing of credit card radio button for each design style.

### Trendy - Shipping Radio Buttons
![image](https://user-images.githubusercontent.com/5321364/109227594-8ed02880-778e-11eb-881d-5636ade48514.png)

### Trendy - Credit Card Radio Buttons Now Fixed
![image](https://user-images.githubusercontent.com/5321364/109227668-ae675100-778e-11eb-94a0-3695d55a3e65.png)

### Modern - Credit Card Radio Buttons Now Fixed
![image](https://user-images.githubusercontent.com/5321364/109227703-baeba980-778e-11eb-8621-627c323e892f.png)