### PR TITLE
Remove Carousel block overlay styles

### DIFF
--- a/.dev/assets/shared/css/blocks/carousel/_style.scss
+++ b/.dev/assets/shared/css/blocks/carousel/_style.scss
@@ -5,24 +5,6 @@
 		margin: 0;
 	}
 
-	.coblocks-gallery--figure::before {
-		background-color: var(--wp-block-coblocks-gallery-carousel--overlay--color--background, var(--go--color--primary));
-		content: "";
-		height: 100%;
-		opacity: 0;
-		position: absolute;
-		transition: opacity 200ms cubic-bezier(0.7, 0, 0.3, 1), background-color 200ms cubic-bezier(0.7, 0, 0.3, 1);
-		width: 100%;
-		z-index: 19;
-	}
-
-	.has-aligned-cells .coblocks-gallery--figure::before {
-		display: none;
-	}
-
-	.coblocks-gallery--item:not(.is-selected) .coblocks-gallery--figure::before {
-		opacity: var(--wp-block-coblocks-gallery-carousel--overlay--opacity, 0.75);
-	}
 
 	+ .wp-block-coblocks-gallery-stacked {
 		margin-top: 0 !important;


### PR DESCRIPTION
These styles here have been revealed to prevent event bubbling in the Carousel block and should be removed.

PR on CoBlocks to introduce replacement image flow to all gallery blocks. https://github.com/godaddy-wordpress/coblocks/pull/1870
