### PR TITLE
Fix header 2 submenu alignment

### DIFF
--- a/.dev/assets/shared/css/header/header-2.scss
+++ b/.dev/assets/shared/css/header/header-2.scss
@@ -47,6 +47,10 @@
 			& li:not(:last-child) {
 				margin-right: var(--go-navigation--padding--x, 2vw);
 			}
+
+			& ul.sub-menu li.menu-item {
+				margin-right: inherit;
+			}
 		}
 
 		& .header__extras {


### PR DESCRIPTION
Resolves https://github.com/godaddy-wordpress/go/issues/651

Fix the `margin-right` on the header 2 submenu.

<img src="https://user-images.githubusercontent.com/5321364/113222714-91261680-9255-11eb-80d7-3edfc4faa34e.png" width="400" />
