### PR TITLE
[WPEX-1281]  button block appender should be to the side of the block

### DIFF
--- a/.dev/assets/shared/css/editor/vertical-rhythm.scss
+++ b/.dev/assets/shared/css/editor/vertical-rhythm.scss
@@ -39,12 +39,3 @@
 .wp-block[data-type="core/image"][data-align="full"] + .wp-block[data-type="core/group"][data-align="full"] .has-background {
 	margin-top: calc(var(--go--spacing--vertical--lg) * -1);
 }
-
-/* Remove spacing from the first and last blocks */
-.block-editor-block-list__layout .wp-block.block-editor-block-list__block:first-of-type {
-	margin-top: 0 !important;
-}
-
-.block-editor-block-list__layout .wp-block.block-editor-block-list__block:last-of-type {
-	margin-top: 0 !important;
-}

--- a/.dev/assets/shared/css/style-editor.scss
+++ b/.dev/assets/shared/css/style-editor.scss
@@ -15,6 +15,10 @@
 	top: 0 !important;
 }
 
+.wp-block-button {
+	margin-bottom: var(--go--spacing--vertical) !important;
+}
+
 // Add padding to the editor.
 body {
 	padding-left: var(--go-block--padding--x);

--- a/.dev/assets/shared/css/style-editor.scss
+++ b/.dev/assets/shared/css/style-editor.scss
@@ -10,6 +10,10 @@
 @import "editor/title-block";
 @import "editor/title-permalink";
 
+.block-list-appender {
+	width: auto !important;
+}
+
 // Add padding to the editor.
 body {
 	padding-left: var(--go-block--padding--x);

--- a/.dev/assets/shared/css/style-editor.scss
+++ b/.dev/assets/shared/css/style-editor.scss
@@ -12,6 +12,7 @@
 
 .block-list-appender {
 	width: auto !important;
+	top: 0 !important;
 }
 
 // Add padding to the editor.


### PR DESCRIPTION
This PR fixes the button block appender width to auto so that the appender is positioned next to the button block

<img width="386" alt="Screen Shot 2021-05-14 at 5 07 08 PM" src="https://user-images.githubusercontent.com/18115694/118331902-4267cf80-b4d7-11eb-9878-252c70ee2440.png">
