### PR TITLE
Fix styling inconsistencies

### DIFF
--- a/.dev/assets/shared/css/blocks/pullquote/_style.scss
+++ b/.dev/assets/shared/css/blocks/pullquote/_style.scss
@@ -53,7 +53,7 @@
 
 		blockquote {
 			max-width: 100%;
-			padding: calc(var(--go--spacing--vertical--lg) * 0.35) calc(var(--go--spacing--vertical--lg) * 0.35);
+			padding: calc(var(--go--spacing--vertical--lg)) calc(var(--go--spacing--vertical--lg));
 
 
 			p {

--- a/.dev/assets/shared/css/blocks/quote/_style.scss
+++ b/.dev/assets/shared/css/blocks/quote/_style.scss
@@ -1,3 +1,14 @@
+.wp-block-quote:not([style]){
+	p {
+		color: var(--go-quote--color--text, var(--go-heading--color--text));
+	}
+	&:not(.is-style-large) {
+		p {
+			color: var(--go-quote--color--text, var(--go-heading--color--text));
+		}
+	}
+}
+
 /*! Blockquote */
 .wp-block-quote {
 	margin-bottom: calc(var(--go--spacing--vertical--lg) * 0.5);
@@ -6,7 +17,6 @@
 	margin-top: calc(var(--go--spacing--vertical--lg) * 0.5);
 
 	p {
-		color: var(--go-quote--color--text, var(--go-heading--color--text));
 		font-display: swap;
 		font-family: var(--go-heading--font-family);
 		font-size: var(--go-quote--font-size, var(--go--type-scale-4));
@@ -32,7 +42,6 @@
 		padding-right: 0;
 
 		p {
-			color: var(--go-quote--color--text, var(--go-heading--color--text));
 			padding-left: 1.5rem;
 
 			@include media(medium) {

--- a/.dev/assets/shared/css/blocks/verse/_style.scss
+++ b/.dev/assets/shared/css/blocks/verse/_style.scss
@@ -4,5 +4,4 @@ pre {
 	line-height: 1.5;
 	overflow: auto;
 	padding: 3rem 2rem;
-	text-align: left;
 }

--- a/.dev/assets/shared/css/blocks/verse/_style.scss
+++ b/.dev/assets/shared/css/blocks/verse/_style.scss
@@ -4,4 +4,8 @@ pre {
 	line-height: 1.5;
 	overflow: auto;
 	padding: 3rem 2rem;
+
+	&:not([class*="has-text-align-"]) {
+		text-align: left;
+	}
 }

--- a/.dev/assets/shared/css/elements/typography.scss
+++ b/.dev/assets/shared/css/elements/typography.scss
@@ -24,8 +24,13 @@ p {
 	padding-left: 0;
 	padding-right: 0;
 
+	&:not([style]){
+		p {
+			color: var(--go-quote--color--text, var(--go-heading--color--text));
+		}
+	}
+
 	& p {
-		color: var(--go-quote--color--text, var(--go-heading--color--text));
 		font-display: swap;
 		font-family: var(--go-heading--font-family);
 		font-size: var(--go-quote--font-size, var(--go--type-scale-4));

--- a/.dev/assets/shared/css/elements/typography.scss
+++ b/.dev/assets/shared/css/elements/typography.scss
@@ -82,5 +82,8 @@ pre {
 	line-height: 1.5;
 	overflow: auto;
 	padding: 3rem 2rem;
-	text-align: left;
+
+	&:not([class*="has-text-align-"]) {
+		text-align: left;
+	}
 }


### PR DESCRIPTION
This PR includes necessary changes to Go to resolve the styling issues outlined in https://github.com/godaddy-wordpress/coblocks/issues/1902.

Go was overriding the user's selected color on core/quote block, so this updates the quote block styling to remedy that.