### PR TITLE
Change copyright text and relevant tests to "Go by GoDaddy"

### DIFF
--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -984,7 +984,7 @@ class Test_Core extends WP_UnitTestCase {
 	 */
 	function testGetDefaultCopyright() {
 
-		$this->assertEquals( 'Test Blog', Go\Core\get_default_copyright() );
+		$this->assertEquals( 'Go by GoDaddy', Go\Core\get_default_copyright() );
 
 	}
 

--- a/.dev/tests/php/test-template-tags.php
+++ b/.dev/tests/php/test-template-tags.php
@@ -958,7 +958,7 @@ class Test_Template_Tags extends WP_UnitTestCase {
 			return $args;
 		} );
 
-		$this->expectOutputRegex( '/Test Blog/' );
+		$this->expectOutputRegex( '/Go by GoDaddy/' );
 
 		Go\footer_variation();
 
@@ -1024,7 +1024,7 @@ class Test_Template_Tags extends WP_UnitTestCase {
 	 */
 	public function test_copyright() {
 
-		$this->expectOutputRegex( '/Test Blog/' );
+		$this->expectOutputRegex( '/Go by GoDaddy/' );
 
 		Go\copyright();
 

--- a/includes/core.php
+++ b/includes/core.php
@@ -1127,7 +1127,7 @@ function get_default_copyright() {
 	 * @param string $copyright The default text for copyright.
 	 */
 	/* translators: the theme author */
-	return (string) apply_filters( 'go_default_copyright', get_bloginfo( 'name' ) );
+	return (string) apply_filters( 'go_default_copyright', sprintf( esc_html__( 'Go by %s', 'go' ), 'GoDaddy' ) );
 
 }
 


### PR DESCRIPTION
Reverts changes in #481 to include GoDaddy copyright in footer, as well as updates tests to check for the proper text. 