### PR TITLE
WPEX-1485 Apply the same styles to title with or without Gutenberg active

### DIFF
--- a/.dev/assets/shared/css/style-editor.scss
+++ b/.dev/assets/shared/css/style-editor.scss
@@ -10,6 +10,11 @@
 @import "editor/title-block";
 @import "editor/title-permalink";
 
+.editor-post-title__input {
+	text-align: center;
+	padding: 19px 0;
+}
+
 // Add padding to the editor.
 body {
 	padding-left: var(--go-block--padding--x);


### PR DESCRIPTION
This PR adds styles to the `.editor-post-title__input` class to persist the Go styles on the title with or without Gutenberg active.