### PR TITLE
Update styles to prevent override of user set text color

### DIFF
--- a/.dev/assets/shared/css/utilities/colors.scss
+++ b/.dev/assets/shared/css/utilities/colors.scss
@@ -1,21 +1,27 @@
 /*! Color Utility Classes */
 :root {
 
+	:not(.has-text-color) {
+
+		> .has-primary-background-color:not(.has-text-color) {
+				color: var(--go--color--white);
+	
+				label,
+				h1:not([class*="color"]),
+				h2:not([class*="color"]),
+				h3:not([class*="color"]),
+				h4:not([class*="color"]),
+				h5:not([class*="color"]),
+				h6:not([class*="color"]),
+				p:not([class*="color"]),
+				a:not(.wp-block-button__link) {
+					color: var(--go--color--white);
+				}
+		}
+	}
+
 	.has-primary-background-color {
 		background-color: var(--go--color--primary);
-
-		&,
-		label,
-		h1:not([class*="color"]),
-		h2:not([class*="color"]),
-		h3:not([class*="color"]),
-		h4:not([class*="color"]),
-		h5:not([class*="color"]),
-		h6:not([class*="color"]),
-		p:not([class*="color"]),
-		a:not(.wp-block-button__link) {
-			color: var(--go--color--white);
-		}
 	}
 
 	.has-primary-color {


### PR DESCRIPTION
Tested against Alert, Hero, Cover, Accordion, Highlight. No regression was detected.

**Custom color in editor**
![image](https://user-images.githubusercontent.com/30462574/135534730-0e0e6895-969f-48e5-8c06-bfaac95e4a0b.png)

**Custom color on front-end (bug)**
![image](https://user-images.githubusercontent.com/30462574/135534859-be5f7a40-81ca-476c-9c07-79b455a093c0.png)

With this bug fix in place, custom colors will persist on the front-end and editor.