### PR TITLE
Add quote formatting to back end

### DIFF
--- a/.dev/assets/shared/css/elements/typography.scss
+++ b/.dev/assets/shared/css/elements/typography.scss
@@ -17,7 +17,7 @@ p {
 	line-height: var(--go--line-height);
 }
 
-.content-area > blockquote {
+blockquote {
 	border-left: var(--go-quote--border-width) var(--go-quote--border-style) var(--go-quote--border-color);
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
Related to https://github.com/godaddy-wordpress/coblocks/pull/2055.

Style for quotes were enqueued but because of wrong selector, they weren't showing up correctly.