### PR TITLE
Introduce go_use_google_fonts filter to disable Google fonts

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -275,7 +275,7 @@ function theme_setup() {
 function fonts_url() {
 
 	/**
-	 * Filter to disable Google fonts from loading ont the site.
+	 * Filter to disable Google fonts from loading on the site.
 	 *
 	 * @var bool
 	 */


### PR DESCRIPTION
Closes https://github.com/godaddy-wordpress/go/issues/600

Setting this to true will disable Google fonts on the site. This includes front end and editor.

### Usage:
```php
add_filter( 'go_use_google_fonts', '__return_false' );
```