### PR TITLE
Fix WooCommerce shop button styles, and success message styles on cart

### DIFF
--- a/.dev/assets/shared/css/woocommerce/button.scss
+++ b/.dev/assets/shared/css/woocommerce/button.scss
@@ -57,7 +57,6 @@ body {
 					font-size: 16px;
 					line-height: 1;
 					margin-left: 1rem;
-					position: absolute;
 					right: 1rem;
 					top: auto;
 					vertical-align: bottom;

--- a/.dev/assets/shared/css/woocommerce/notice.scss
+++ b/.dev/assets/shared/css/woocommerce/notice.scss
@@ -26,6 +26,19 @@
 	}
 }
 
+body.woocommerce-cart {
+
+	& .woocommerce-message {
+		display: flex;
+		flex-direction: column-reverse;
+
+		& a.button,
+		& a.restore-item {
+			align-self: flex-start;
+		}
+	}
+}
+
 body.admin-bar .woocommerce-store-notice.demo_store {
 	top: initial;
 }

--- a/.dev/assets/shared/css/woocommerce/notice.scss
+++ b/.dev/assets/shared/css/woocommerce/notice.scss
@@ -28,12 +28,12 @@
 
 body.woocommerce-cart {
 
-	& .woocommerce-message {
+	.woocommerce-message {
 		display: flex;
 		flex-direction: column-reverse;
 
-		& a.button,
-		& a.restore-item {
+		a.button,
+		a.restore-item {
 			align-self: flex-start;
 		}
 	}

--- a/.dev/assets/shared/css/woocommerce/shop.scss
+++ b/.dev/assets/shared/css/woocommerce/shop.scss
@@ -80,8 +80,12 @@
 			/* Add to cart button appears on Shop page after ajax load */
 			&.added_to_cart {
 				border: none;
-				margin: 0.5rem 0 0 1rem;
-				padding-top: 0;
+				bottom: -35px;
+				left: 0;
+				margin: 0 auto;
+				position: absolute;
+				right: 0;
+				width: 50%;
 			}
 		}
 


### PR DESCRIPTION
- Tweak the 'View Cart' link when no AJAX redirect to cart is enabled.
- Tweak the checkmark after an item is added to the cart when no AJAX redirect to cart is enabled.

- Tweak the success notice styles on the cart page after an item is added to the cart and AJAX redirect is enabled.
- Tweak the success notice styles on the cart page when an item is removed from the cart.

### Current
![image](https://user-images.githubusercontent.com/5321364/137806106-b9b8e251-7cd1-4f92-a441-91a853ef99e9.png)

### After PR
![image](https://user-images.githubusercontent.com/5321364/137806001-731580fe-9aa3-4a06-96c5-0ecc4f1f0bf9.png)