### PR TITLE
Fix comment navigation header and output

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -58,9 +58,9 @@ if ( post_password_required() ) {
 
 			<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : ?>
 			<nav id="comment-nav-below" class="navigation" role="navigation">
-				<h1 class="assistive-text section-heading"><?php esc_html_e( 'Comment navigation', 'go' ); ?></h1>
-				<div class="nav-previous"><?php previous_comments_link( esc_html_e( '&larr; Older Comments', 'go' ) ); ?></div>
-				<div class="nav-next"><?php next_comments_link( esc_html_e( 'Newer Comments &rarr;', 'go' ) ); ?></div>
+				<h4 class="assistive-text section-heading"><?php esc_html_e( 'Comment navigation', 'go' ); ?></h4>
+				<div class="nav-previous"><?php previous_comments_link( esc_html__( '&larr; Older Comments', 'go' ) ); ?></div>
+				<div class="nav-next"><?php next_comments_link( esc_html__( 'Newer Comments &rarr;', 'go' ) ); ?></div>
 			</nav>
 			<?php endif; ?>
 


### PR DESCRIPTION
Resolves https://github.com/godaddy-wordpress/go/issues/582

As described in the issue above, the comment navigation template was wrapped in the incorrect i18n tags and was outputting incorrectly.

I've also swapped out the `Comment Navigation` `h1` element for an `h4` element, since the post/page title should be the only `h1` element on the page.

### Current
![image](https://user-images.githubusercontent.com/5321364/137809201-136e5635-2ef4-41cd-894d-c70fb5089291.png)

### PR
![image](https://user-images.githubusercontent.com/5321364/137808984-65a10dfe-5d02-4c08-9888-f65e64b3cf6b.png)
