### PR TITLE
Don't override styles of the social-link block

### DIFF
--- a/.dev/assets/shared/css/editor/horizontal-rhythm.scss
+++ b/.dev/assets/shared/css/editor/horizontal-rhythm.scss
@@ -1,7 +1,7 @@
 .wp-block {
 	max-width: var(--go--max-width);
 
-	.wp-block:not(.wp-block-button) {
+	.wp-block:not(.wp-block-button):not(.wp-social-link) {
 		width: 100%;
 	}
 

--- a/.dev/assets/shared/css/editor/vertical-rhythm.scss
+++ b/.dev/assets/shared/css/editor/vertical-rhythm.scss
@@ -5,7 +5,7 @@
 }
 
 //Spacing for child blocks
-.block-editor-block-list__layout > .wp-block {
+.block-editor-block-list__layout > .wp-block:not(.wp-social-link) {
 
 	&:first-child {
 


### PR DESCRIPTION
Fixes `core/social-link` styles.

Before:

![image](https://user-images.githubusercontent.com/375788/139500594-a08242b2-d9a3-46a8-a142-3535fbd030da.png)

After:

![image](https://user-images.githubusercontent.com/375788/139500512-be949287-8c98-48cd-b658-efb7979297e4.png)