### PR TITLE
Full Site Editing in version 2.0

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,8 @@
+{
+  "themes": [
+    "."
+  ],
+  "plugins": [
+    "https://downloads.wordpress.org/plugin/gutenberg.latest-stable.zip"
+  ]
+}

--- a/footer.php
+++ b/footer.php
@@ -7,9 +7,13 @@
 
 ?>
 
-	</main>
+		</main>
 
-	<?php Go\footer_variation(); ?>
+		<footer class="wp-block-template-part">
+			<?php
+			echo do_blocks( file_get_contents( get_stylesheet_directory() . '/go-block-template-parts/footer-01.html' ) );
+			?>
+		</footer>
 
 	</div>
 

--- a/go-block-template-parts/commerce-01.html
+++ b/go-block-template-parts/commerce-01.html
@@ -1,0 +1,3 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/commerce-01.html</code></pre>
+<!-- /wp:code -->

--- a/go-block-template-parts/content-01.html
+++ b/go-block-template-parts/content-01.html
@@ -1,0 +1,3 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/content-01.html</code></pre>
+<!-- /wp:code -->

--- a/go-block-template-parts/footer-01.html
+++ b/go-block-template-parts/footer-01.html
@@ -1,0 +1,3 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/footer-01.html</code></pre>
+<!-- /wp:code -->

--- a/go-block-template-parts/footer-02.html
+++ b/go-block-template-parts/footer-02.html
@@ -1,0 +1,3 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/footer-02.html</code></pre>
+<!-- /wp:code -->

--- a/go-block-template-parts/footer-03.html
+++ b/go-block-template-parts/footer-03.html
@@ -1,0 +1,3 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/footer-03.html</code></pre>
+<!-- /wp:code -->

--- a/go-block-template-parts/header-01.html
+++ b/go-block-template-parts/header-01.html
@@ -1,0 +1,19 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/header-01.html</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:group -->
+<div class="wp-block-group">
+	<!-- wp:site-title /-->
+
+	<!-- wp:site-tagline /-->
+
+	<!-- wp:navigation {"itemsJustification":"space-between","showSubmenuIcon":false,"isResponsive":true} -->
+	<!-- wp:navigation-link {"label":"LinkOne","type":"custom","url":"https://godaddy.com","kind":"custom","isTopLevelLink":true} /-->
+	<!-- wp:navigation-link {"label":"LinkTwo","type":"custom","url":"https://godaddy.com","kind":"custom","isTopLevelLink":true} /-->
+	<!-- wp:navigation-link {"label":"LinkThree","type":"custom","url":"https://godaddy.com","kind":"custom","isTopLevelLink":true} /-->
+	<!-- /wp:navigation -->
+
+	<!-- wp:page-list /-->
+</div>
+<!-- /wp:group -->

--- a/go-block-template-parts/header-02.html
+++ b/go-block-template-parts/header-02.html
@@ -1,0 +1,3 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/header-02.html</code></pre>
+<!-- /wp:code -->

--- a/go-block-template-parts/header-03.html
+++ b/go-block-template-parts/header-03.html
@@ -1,0 +1,3 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-template-parts/header-03.html</code></pre>
+<!-- /wp:code -->

--- a/go-block-template-parts/index.html
+++ b/go-block-template-parts/index.html
@@ -1,0 +1,4 @@
+
+<!-- wp:paragraph -->
+<p>block-templates/index.html</p>
+<!-- /wp:paragraph -->

--- a/go-block-templates/index.html
+++ b/go-block-templates/index.html
@@ -1,0 +1,33 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-templates/index.html</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:query {"tagName":"main","layout":{"inherit":true}} -->
+<main class="wp-block-query">
+	<!-- wp:query-title {"type":"archive","style":{"spacing":{"margin":{"bottom":"100px"}}}} /-->
+	<!-- wp:post-template -->
+	<!-- wp:group -->
+	<div class="wp-block-group">
+		<!-- wp:post-title {"isLink":true} /-->
+		<!-- wp:post-featured-image {"isLink":true} /-->
+		<!-- wp:post-excerpt /-->
+		<!-- wp:template-part {"slug":"post-meta-icons","layout":{"inherit":true}} /-->
+		<!-- wp:spacer {"height":40} -->
+		<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->
+	</div>
+	<!-- /wp:group -->
+	<!-- /wp:post-template -->
+	<!-- wp:group {"layout":{"inherit":true}} -->
+	<div class="wp-block-group">
+		<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:query -->

--- a/go-block-templates/page.html
+++ b/go-block-templates/page.html
@@ -1,0 +1,21 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-templates/page.html</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+	<!-- wp:post-title /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:post-featured-image {"align":"full"} /-->
+
+	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":60} -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/go-block-templates/single.html
+++ b/go-block-templates/single.html
@@ -1,0 +1,28 @@
+<!-- wp:code -->
+<pre class="wp-block-code"><code>block-templates/single.html</code></pre>
+<!-- /wp:code -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+	<!-- wp:post-title /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+	<!-- wp:post-featured-image {"align":"full"} /-->
+
+	<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+	<!-- wp:template-part {"slug":"post-meta-icons","layout":{"inherit":true}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+	<!-- wp:spacer {"height":60} -->
+	<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:post-comments /-->
+</div>
+<!-- /wp:group -->

--- a/index.php
+++ b/index.php
@@ -14,23 +14,6 @@
 
 get_header();
 
-Go\page_title();
-
-if ( have_posts() ) {
-
-	// Start the Loop.
-	while ( have_posts() ) :
-		the_post();
-		get_template_part( 'partials/content' );
-	endwhile;
-
-	// Previous/next page navigation.
-	get_template_part( 'partials/pagination' );
-
-} else {
-
-	// If no content, include the "No posts found" template.
-	get_template_part( 'partials/content', 'none' );
-}
+echo do_blocks( file_get_contents( get_stylesheet_directory() . '/go-block-templates/index.html' ) );
 
 get_footer();

--- a/page.php
+++ b/page.php
@@ -9,16 +9,6 @@
 
 get_header();
 
-// Start the Loop.
-while ( have_posts() ) :
-	the_post();
-	get_template_part( 'partials/content', 'page' );
-
-	// If comments are open or we have at least one comment, load up the comment template.
-	if ( comments_open() || get_comments_number() ) {
-		comments_template();
-	}
-
-endwhile;
+echo do_blocks( file_get_contents( get_stylesheet_directory() . '/go-block-templates/page.html' ) );
 
 get_footer();

--- a/single.php
+++ b/single.php
@@ -8,16 +8,6 @@
 
 get_header();
 
-// Start the Loop.
-while ( have_posts() ) :
-	the_post();
-	get_template_part( 'partials/content' );
-
-	// If comments are open or we have at least one comment, load up the comment template.
-	if ( comments_open() || get_comments_number() ) {
-		comments_template();
-	}
-
-endwhile;
+echo do_blocks( file_get_contents( get_stylesheet_directory() . '/go-block-templates/single.html' ) );
 
 get_footer();

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json.schemastore.org/theme-v1.json",
+  "version": 1,
+  "templateParts": [
+    {
+      "name": "header-01",
+      "area": "header"
+    },
+    {
+      "name": "header-02",
+      "area": "header"
+    },
+    {
+      "name": "header-03",
+      "area": "header"
+    },
+    {
+      "name": "footer-01",
+      "area": "footer"
+    },
+    {
+      "name": "footer-02",
+      "area": "footer"
+    },
+    {
+      "name": "footer-03",
+      "area": "footer"
+    },
+    {
+      "name": "content-01",
+      "area": "content"
+    },
+    {
+      "name": "commerce-01",
+      "area": "commerce"
+    }
+  ],
+  "settings": {
+    "border": {
+      "customColor": true,
+      "customRadius": true,
+      "customStyle": true,
+      "customWidth": true
+    },
+    "color": {
+      "gradients": [],
+      "palette": [
+        {
+          "slug": "primary",
+          "color": "#007cba",
+          "name": "Primary"
+        },
+        {
+          "slug": "secondary",
+          "color": "#006ba1",
+          "name": "Secondary"
+        },
+        {
+          "slug": "foreground",
+          "color": "#333333",
+          "name": "Foreground"
+        },
+        {
+          "slug": "background",
+          "color": "#ffffff",
+          "name": "Background"
+        },
+        {
+          "slug": "tertiary",
+          "color": "#FAFAFA",
+          "name": "Tertiary"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Full Site Editing with Go

With full-site editing coming into WordPress 5.9 we needed to answer some questions around how Go can become a FSE theme without starting from scratch.

The biggest question we need to answer is how do we maintain backwards compatibility in our existing theme. It is unacceptable for us to create a brand new theme just for FSE support and instead we would like to support existing users while (as seamlessly as possible) upgrading users to FSE when it is available to them.

So how do we continue support existing users without FSE while utilizing the new features FSE provides?

## Begin utilizing theme.json

In my experiment of rebuilding our [Barista](https://wpnux.godaddy.com/v2/?template=barista) design template from PHP templates to block templates, I discovered that we can partially trigger FSE functionality without triggering the FSE interface entirely. By providing a `theme.json` file in the theme directory without the `block-templates/index.html` file, it seems that WordPress will still load the `theme.json` file and generate all the custom css properties on the front-end. This will give us an iterative approach to enabling FSE.

The primary purpose of the `theme.json` file is to provide a baseline design framework from which our design styles can build from. We need to rethink and/or ensure our design styles adhere to the same baseline standard. This may require standardizing things such as our [color slugs](https://richtabor.com/standardizing-theme-json-colors/), [font sizes](https://richtabor.com/standardizing-theme-json-font-sizes/), [spacings](https://richtabor.com/standardizing-theme-json-spacing/), and [responsive breakpoints](https://richtabor.com/fluid-type-scale-theme-json/).

In my experiment around the [Barista](https://wpnux.godaddy.com/v2/?template=barista) design I was able to remove a significant amount of custom styles by leaning on `theme.json` and individual blocks to provide the needed styles.

Barista theme in current version of Go:

![go-classic-theme](https://user-images.githubusercontent.com/375788/141001535-2573b78d-4fdb-4431-8b58-db402969d52d.png)

Barista theme built with FSE:

![go-full-site-editing](https://user-images.githubusercontent.com/375788/141001557-6cf3f779-246a-42de-b388-7578abcb9613.png)

## Migrate existing templates and template parts into block templates

In order to take advantage of blocks in any capacity as a full on block theme we need to begin rebuilding our templates and template parts using blocks. To do this without creating a `block-templates` directory and triggering the FSE interface we should create our own `go-block-templates` and `go-block-template-parts` directories to store and manually load these new templates.

We can build these templates using the FSE interface and then exporting the templates into the appropriate directories. We would need to create the following templates:

1. `go-block-templates/index.html`
2. `go-block-templates/page.html`
3. `go-block-templates/single.html`
4. `go-block-template-parts/header-01.html`
5. `go-block-template-parts/header-02.html`
6. `go-block-template-parts/header-03.html`
7. `go-block-template-parts/header-04.html`
8. `go-block-template-parts/header-05.html`
9. `go-block-template-parts/header-06.html`
10. `go-block-template-parts/header-07.html`
11. `go-block-template-parts/footer-01.html`
12. `go-block-template-parts/footer-02.html`
13. `go-block-template-parts/footer-03.html`
14. `go-block-template-parts/footer-04.html`

## Maintain Customizer controls

Because we are wanting to prevent the FSE interface from loading right now we need to maintain the current customizer controls and their functionality. Eventually all the functionality that lives here will move into the global styles sidebar within FSE or into a custom sidebar we create ourselves depending on what features are supported by core at the time.

## Utilize existing PHP templates to load our Block based templates

Currently the experience for users modifying their site design in FSE can still be confusing for our target user, specifically around header and footer variations and the ability to swap to a new template part. Our customizer controls currently provide the ideal experience we're looking for and applies the header or footer design variation to the site globally.

By not triggering the full FSE experience and continuing to utilize our PHP templates, we can replace a majority of the PHP and HTML code in each template with a simple line to pull the block based template and render its blocks.

```
echo do_blocks( file_get_contents( get_stylesheet_directory() . '/go-block-templates/index.html' ) );
```

This one line allows us to still be conditional in how we load templates and use block templates while controlling the experience. There is a function in Gutenberg that makes this easier but is considered a private function and shouldn't be used. There does not yet (and my not ever) exist a hook for filtering where WordPress should look for the block templates so this manual method is the best right now.

This method also allows us to be iterative in our approach to utilizing these templates. We can gradually start replacing header variations with the block template version without needing to change everything over to the block templates.

# Final Verdict

There are a lot of benefits in moving towards Go as a FSE theme and although development has progressed at an impressive rate, it has not been merged into Core yet (though it will be released in WP 5.9). That said there are still some friction areas that are easy to trip up on and I don't think brings the level of user experience our customers expect.

In my opinion, an iterative approach as I've described above would be most beneficial and as we move forward I expect FSE to make significantly more progress which would allow us to adopt more and more features until we are fully integrated. I expect most of the community will make brand new themes focused on FSE rather than take this kind of inexpedient approach.