### PR TITLE
WPEX-1626 shared padding classes are being overwritten by coblocks

### DIFF
--- a/.dev/assets/shared/css/utilities/padding.scss
+++ b/.dev/assets/shared/css/utilities/padding.scss
@@ -1,28 +1,28 @@
 /*! Editor Padding Sizes */
 .has-small-padding {
-	padding: var(--go--spacing--vertical);
+	padding: var(--go--spacing--vertical) !important;
 
 	@include media(medium) {
-		padding: calc(var(--go--spacing--vertical--lg) * 0.2);
+		padding: calc(var(--go--spacing--vertical--lg) * 0.2) !important;
 	}
 }
 
 .has-medium-padding {
-	padding: var(--go--spacing--vertical);
+	padding: var(--go--spacing--vertical) !important;
 
 	@include media(medium) {
-		padding: calc(var(--go--spacing--vertical--lg) * 0.5);
+		padding: calc(var(--go--spacing--vertical--lg) * 0.5) !important;
 	}
 }
 
 .has-large-padding {
-	padding: var(--go--spacing--vertical);
+	padding: var(--go--spacing--vertical) !important;
 
 	@include media(medium) {
-		padding: calc(var(--go--spacing--vertical--lg) * 0.75);
+		padding: calc(var(--go--spacing--vertical--lg) * 0.75) !important;
 	}
 }
 
 .has-huge-padding {
-	padding: var(--go--spacing--vertical--lg);
+	padding: var(--go--spacing--vertical--lg) !important;
 }


### PR DESCRIPTION
The shared classes `has-*-padding` are not being applied in the front end when Go is active. The coblocks styles are being applied instead. This PR will override the plugin styles with the theme styles.