### PR TITLE
Fix PR comment, edit last bot comment only

### DIFF
--- a/.dev/bin/comment-on-pr.sh
+++ b/.dev/bin/comment-on-pr.sh
@@ -50,7 +50,7 @@ BOT_COMMENTS=$(curl -sS \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$PR_ID/comments")
 
-COMMENT=$(echo $BOT_COMMENTS | jq '.[-1]')
+COMMENT=$(echo $BOT_COMMENTS | jq '[.[] | select( .user.login == "godaddy-wordpress-bot" )]' | jq '.[-1]')
 
 # Bot has not commented on the issue, create new comment
 if [ 'null' == "$COMMENT" ]; then


### PR DESCRIPTION
Uncovered in https://github.com/godaddy-wordpress/coblocks/pull/2162, the PR comment job was overwriting the last comment by anyone, not just the godaddy bot. This PR fixes that, so it pulls only the last comment by the godaddy bot.