### PR TITLE
Ignore width 100 on appender

### DIFF
--- a/.dev/assets/shared/css/editor/horizontal-rhythm.scss
+++ b/.dev/assets/shared/css/editor/horizontal-rhythm.scss
@@ -1,7 +1,7 @@
 .wp-block {
 	max-width: var(--go--max-width);
 
-	.wp-block:not(.wp-block-button):not(.wp-social-link) {
+	.wp-block:not(.wp-block-button):not(.wp-social-link):not(.block-list-appender) {
 		width: 100%;
 	}
 


### PR DESCRIPTION
The appender also add wp-block to the list of classnames. We should avoid adding with 100% on this theme.