### PR TITLE
Fix build path to images

### DIFF
--- a/.dev/config/webpack.settings.js
+++ b/.dev/config/webpack.settings.js
@@ -67,7 +67,8 @@ module.exports = {
 	copyWebpackConfig: {
 		from: '.dev/assets/**/*.{jpg,jpeg,png,gif,svg}',
 		to({ context, absoluteFilename }) {
-			return 'images/' + absoluteFilename.replace( /^.*(\.dev\/assets\/)/g, '' ).replace( 'images/', '');
+			// Remove everything before .dev/assets/, remove images/, remove shared/
+			return 'images/' + absoluteFilename.replace( /^.*(\.dev\/assets\/)/g, '' ).replace( 'images/', '' ).replace( 'shared/', '' );
 		},
 	},
 	BrowserSyncConfig: {

--- a/.dev/config/webpack.settings.js
+++ b/.dev/config/webpack.settings.js
@@ -67,8 +67,8 @@ module.exports = {
 	copyWebpackConfig: {
 		from: '.dev/assets/**/*.{jpg,jpeg,png,gif,svg}',
 		to({ context, absoluteFilename }) {
-			return 'images/' + absoluteFilename.replace( /^.*(\.dev\/assets\/|images\/|shared\/)/g, '' );
-        },
+			return 'images/' + absoluteFilename.replace( /^.*(\.dev\/assets\/)/g, '' ).replace( 'images/', '');
+		},
 	},
 	BrowserSyncConfig: {
 		host: 'localhost',


### PR DESCRIPTION
The webkit config was altered when we migrated to `yarn` and the images paths were not being set correct in the dist directory after a build. This PR fixes it so images appear in the expected directories in `dist/images/`.

<img src="https://user-images.githubusercontent.com/5321364/150014776-b6d9a8cd-8964-4ceb-92a8-e1e5284fccdd.png" width="200" />

<img src="https://user-images.githubusercontent.com/5321364/150013554-d38d28a9-58f8-414a-80de-8109df1ae23a.png" width="200" />

<img src="https://user-images.githubusercontent.com/5321364/150013580-259b1fe2-8cea-4c56-bd38-65d1e9ac91b6.png" width="200" />
