### PR TITLE
Fix the Modern design style nav underline width

### DIFF
--- a/.dev/assets/design-styles/modern/css/style-modern.scss
+++ b/.dev/assets/design-styles/modern/css/style-modern.scss
@@ -29,7 +29,7 @@
 		transform: scaleX(1);
 		transform-origin: left center;
 		transition: transform 400ms cubic-bezier(0.7, 0, 0.3, 1), background-color 200ms cubic-bezier(0.7, 0, 0.3, 1);
-		width: 96%;
+		width: 100%;
 	}
 
 	@media (hover: hover) {


### PR DESCRIPTION
Resolves #753 

<img width="938" alt="image" src="https://user-images.githubusercontent.com/5321364/159697696-8cfad2ba-17bc-46c3-b622-c5a82c22a539.png">