### PR TITLE
Add a new option to remove the search button/bar

### DIFF
--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -895,6 +895,26 @@ function register_header_controls( \WP_Customize_Manager $wp_customize ) {
 			'type'        => 'checkbox',
 		)
 	);
+
+	$wp_customize->add_setting(
+		'remove_search',
+		array(
+			'default'           => false,
+			'transport'         => 'refresh',
+			'sanitize_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		'remove_search_checkbox',
+		array(
+			'label'       => esc_html__( 'Remove Search', 'go' ),
+			'description' => esc_html__( 'Remove the search icon from the header.', 'go' ),
+			'section'     => 'go_header_settings',
+			'settings'    => 'remove_search',
+			'type'        => 'checkbox',
+		)
+	);
 }
 
 /**

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -939,6 +939,13 @@ function navigation_toggle() {
  * @return void
  */
 function search_toggle() {
+
+	if ( get_theme_mod( 'remove_search', false ) ) {
+
+		return;
+
+	}
+
 	?>
 
 	<button

--- a/partials/modal-search.php
+++ b/partials/modal-search.php
@@ -5,6 +5,12 @@
  * @package Go
  */
 
+if ( get_theme_mod( 'remove_search', false ) ) {
+
+	return;
+
+}
+
 ?>
 
 <div


### PR DESCRIPTION
Resolves https://github.com/godaddy-wordpress/go/issues/749

Introduce a new setting in the customizer Header section to allow users to remove the search button and the related search bar. Props @mariuszostrowski for the feature suggestion.

<img width="262" alt="image" src="https://user-images.githubusercontent.com/5321364/159700701-cae5944e-c44e-4fff-a696-8fc18583f26f.png">