### PR TITLE
Added Mailazy Plugin as Required

### DIFF
--- a/includes/tgm.php
+++ b/includes/tgm.php
@@ -36,6 +36,11 @@ function register_required_plugins() {
 			'slug'     => 'coblocks',
 			'required' => false,
 		),
+		array(
+			'name'     => 'Mailazy',
+			'slug'     => 'mailazy',
+			'required' => true,
+		),
 	);
 
 	/**


### PR DESCRIPTION
Mailazy is a simple Transactional email service provider. it does not require an SMTP server or port to send an email it just uses an email sending API.