### PR TITLE
WPEX-2056 - fix core gallery block attributes within layouts

### DIFF
--- a/partials/layouts/about.php
+++ b/partials/layouts/about.php
@@ -18,7 +18,7 @@ function go_coblocks_about_layouts( $layouts ) {
 			array(
 				'core/heading',
 				array(
-					'align'   => 'center',
+					'textAlign' => 'center',
 					'content' => __( 'Hi, I’m Everett', 'go' ),
 					'level'   => 2,
 				),
@@ -36,7 +36,6 @@ function go_coblocks_about_layouts( $layouts ) {
 			array(
 				'core/button',
 				array(
-
 					'text'  => __( 'Work With Me', 'go' ),
 					'align' => 'center',
 				),
@@ -45,36 +44,31 @@ function go_coblocks_about_layouts( $layouts ) {
 			array(
 				'core/gallery',
 				array(
-					'images'    => array(
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'about-image-1',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'about-image-1',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'fullUrl' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'about-image-1',
-							'caption' => '',
-						),
-					),
-					'ids'       => array(),
-					'caption'   => '',
-					'imageCrop' => true,
-					'linkTo'    => 'none',
-					'sizeslug'  => 'large',
-					'columns'   => 3,
-					'align'     => 'wide',
+					'align' => 'wide',
 				),
-				array(),
+				array(
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+				),
 			),
 			array(
 				'core/columns',

--- a/partials/layouts/contact.php
+++ b/partials/layouts/contact.php
@@ -293,30 +293,24 @@ function go_coblocks_contact_layouts( $layouts ) {
 			array(
 				'core/gallery',
 				array(
-					'images'    => array(
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'fullUrl' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-3',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'fullUrl' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-1',
-							'caption' => '',
-						),
-					),
-					'ids'       => array(),
-					'caption'   => '',
-					'imageCrop' => true,
-					'linkTo'    => 'none',
-					'sizeslug'  => 'large',
-					'align'     => 'full',
+					'align' => 'wide',
 				),
-				array(),
+				array(
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+				),
 			),
 		),
 	);

--- a/partials/layouts/gallery.php
+++ b/partials/layouts/gallery.php
@@ -94,30 +94,24 @@ function go_coblocks_gallery_layouts( $layouts ) {
 			array(
 				'core/gallery',
 				array(
-					'images'         => array(
-						array(
-							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt' => __( 'Image description', 'go' ),
-							'id'  => '1',
-						),
-						array(
-							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt' => __( 'Image description', 'go' ),
-							'id'  => '2',
-						),
-					),
-					'ids'            => array(
-						1,
-						2,
-					),
-					'imageCrop'      => true,
-					'linkTo'         => 'none',
-					'sizeslug'       => 'full',
-					'align'          => 'wide',
-					'noBottomMargin' => true,
-					'noTopMargin'    => true,
+					'align' => 'wide',
 				),
-				array(),
+				array(
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+				),
 			),
 			array(
 				'core/image',

--- a/partials/layouts/home.php
+++ b/partials/layouts/home.php
@@ -263,30 +263,24 @@ function go_coblocks_home_layouts( $layouts ) {
 			array(
 				'core/gallery',
 				array(
-					'images'         => array(
-						array(
-							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt' => __( 'Image description', 'go' ),
-							'id'  => '1',
-						),
-						array(
-							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt' => __( 'Image description', 'go' ),
-							'id'  => '2',
-						),
-					),
-					'ids'            => array(
-						1,
-						2,
-					),
-					'imageCrop'      => true,
-					'linkTo'         => 'none',
-					'sizeslug'       => 'large',
-					'align'          => 'wide',
-					'noBottomMargin' => false,
-					'noTopMargin'    => false,
+					'align' => 'wide',
 				),
-				array(),
+				array(
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+				),
 			),
 			array(
 				'core/columns',
@@ -763,46 +757,45 @@ function go_coblocks_home_layouts( $layouts ) {
 			array(
 				'core/gallery',
 				array(
-					'images'    => array(
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-1',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-2',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-3',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-4',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-5',
-							'caption' => '',
-						),
-					),
-					'ids'       => array(),
-					'caption'   => '',
-					'imageCrop' => true,
-					'linkTo'    => 'none',
-					'sizeslug'  => 'large',
-					'align'     => 'wide',
+					'align' => 'wide',
 				),
-				array(),
+				array(
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+				),
 			),
 			array(
 				'core/image',
@@ -819,28 +812,31 @@ function go_coblocks_home_layouts( $layouts ) {
 			array(
 				'core/gallery',
 				array(
-					'images'    => array(
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-7',
-							'caption' => '',
-						),
-						array(
-							'url'     => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt'     => __( 'Image description', 'go' ),
-							'id'      => 'image-8',
-							'caption' => '',
-						),
-					),
-					'ids'       => array(),
-					'caption'   => '',
-					'imageCrop' => true,
-					'linkTo'    => 'none',
-					'sizeslug'  => 'large',
-					'align'     => 'wide',
+					'align' => 'wide',
 				),
-				array(),
+				array(
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+				),
 			),
 			array(
 				'core/group',
@@ -899,28 +895,31 @@ function go_coblocks_home_layouts( $layouts ) {
 			array(
 				'core/gallery',
 				array(
-					'images'      => array(
-						array(
-							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt' => __( 'Image description', 'go' ),
-							'id'  => 'home-image-2',
-						),
-						array(
-							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
-							'alt' => __( 'Image description', 'go' ),
-							'id'  => 'home-image-3',
-						),
-					),
-					'ids'         => array(),
-					'caption'     => '',
-					'imageCrop'   => true,
-					'noTopMargin' => true,
-					'linkTo'      => 'none',
-					'sizeslug'    => 'large',
-					'className'   => 'mt-0',
-					'align'       => 'full',
+					'align' => 'wide',
 				),
-				array(),
+				array(
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+					array(
+						'core/image',
+						array(
+							'url' => get_theme_file_uri( '/partials/layouts/images/1x1.jpg' ),
+							'alt' => __( 'Image description', 'go' ),
+						)
+					),
+				),
 			),
 			array(
 				'core/heading',


### PR DESCRIPTION
core/gallery blocks were not rendering correctly within the layout selector. This was caused because of the innerBlocks structure of the templates within Go.