### PR TITLE
WPEX 2175: Update CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_74_apache_node_browsers_mysql:
     docker:
-      - image: circleci/php:7.4-apache-node-browsers
+      - image: circleci/php:7.4-apache-node-browsers-legacy
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ commands:
       - run:
           name: Setup WordPress site
           command: |
-            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            sudo docker-php-ext-install gd sockets mysqli exif
             bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
@@ -390,7 +390,7 @@ commands:
       - run:
           name: Setup WordPress site
           command: |
-            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            sudo docker-php-ext-install gd sockets mysqli exif
             bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
@@ -590,7 +590,7 @@ jobs:
       - run:
           name: Setup WordPress site and install the Theme Check package
           command: |
-            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            sudo docker-php-ext-install gd sockets mysqli exif
             bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Run theme check
@@ -616,7 +616,7 @@ jobs:
       - run:
           name: Setup WordPress site
           command: |
-            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            sudo docker-php-ext-install gd sockets mysqli exif
             bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
@@ -682,7 +682,7 @@ jobs:
       - run:
           name: Setup WordPress site
           command: |
-            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            sudo docker-php-ext-install gd sockets mysqli exif
             bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Run a11y tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,7 @@ commands:
       - run:
           name: Install MariaDB
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install mariadb-client
       - install_wpcli
@@ -380,6 +381,7 @@ commands:
       - run:
           name: Install MariaDB
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install mariadb-client
       - install_wpcli
@@ -577,6 +579,7 @@ jobs:
       - run:
           name: Install MariaDB
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install mariadb-client
       - install_wpcli
@@ -663,6 +666,7 @@ jobs:
       - run:
           name: Install MariaDB
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install mariadb-client
       - install_yarn_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  php_74_browsers_mysql:
+  php_74_apache_node_browsers_mysql:
     docker:
-      - image: cimg/php:7.4-browsers
+      - image: circleci/php:7.4-apache-node-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -563,12 +563,12 @@ jobs:
       - run_php_cs
 
   unit-tests:
-    executor: php_74_browsers_mysql
+    executor: php_74_apache_node_browsers_mysql
     steps:
       - run_php_unit_test
 
   theme-check:
-    executor: php_74_browsers_mysql
+    executor: php_74_apache_node_browsers_mysql
     steps:
       - checkout
       - attach_workspace:
@@ -588,7 +588,7 @@ jobs:
           command: wp themecheck --theme=go --no-interactive --path=/var/www/html/wordpress
 
   customizer-e2e:
-    executor: php_74_browsers_mysql
+    executor: php_74_apache_node_browsers_mysql
     steps:
       - run:
           name: Update hosts
@@ -604,14 +604,8 @@ jobs:
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install mariadb-client
       - run:
-          name: Install Apache
-          command: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9
-            sudo apt-get update && sudo apt-get install -y apache2
-      - run:
           name: Setup WordPress site
-          command: sudo bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages
@@ -656,7 +650,7 @@ jobs:
           command: ./node_modules/.bin/cypress run --browser chrome --parallel --record --spec .dev/tests/cypress/integration/customizer/*.js
 
   a11y-tests:
-    executor: php_74_browsers_mysql
+    executor: php_74_apache_node_browsers_mysql
     steps:
       - checkout
       - attach_workspace:
@@ -720,14 +714,14 @@ jobs:
             git push origin master --quiet
 
   visual-regression-chrome:
-    executor: php_74_browsers_mysql
+    executor: php_74_apache_node_browsers_mysql
     parallelism: 30
     steps:
       - run_visual_regression_tests:
           browser: chrome
 
   visual-regression-firefox:
-    executor: php_74_browsers_mysql
+    executor: php_74_apache_node_browsers_mysql
     parallelism: 30
     steps:
       - run_visual_regression_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,49 +3,49 @@ version: 2.1
 executors:
   php_56:
     docker:
-      - image: circleci/php:5.6
+      - image: cimg/php:5.6
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWOR
   php_74:
     docker:
-      - image: circleci/php:7.4
+      - image: cimg/php:7.4
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
   php_80:
     docker:
-      - image: circleci/php:8.0
+      - image: cimg/php:8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  php_74_node_browser_legacy:
+  php_74_browsers:
      docker:
-      - image: circleci/php:7.4-node-browsers-legacy
+      - image: cimg/php:7.4-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  php_74_apache_node_browser_mysql:
+  php_74_browsers_mysql:
     docker:
-      - image: circleci/php:7.4.24-apache-node-browsers
+      - image: cimg/php:7.4-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
           XDEBUG_MODE=coverage
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/mysql:5.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  python_node_browsers:
+  python_310_browsers:
     docker:
-      - image: circleci/python:latest-node-browsers
+      - image: cimg/python:3.10-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  go_node_browsers_legacy:
+  go_1_17_browsers:
     docker:
-      - image: circleci/golang:latest-node-browsers-legacy
+      - image: cimg/go:1.17-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -483,7 +483,7 @@ jobs:
   # 3. Persist project folder to workspace for other jobs.
   build:
     docker:
-      - image: circleci/php:7.3-node
+      - image: cimg/php:7.3-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -531,7 +531,7 @@ jobs:
 
   pr_artifact_comment:
     docker:
-      - image: circleci/php:7.3-node
+      - image: cimg/php:7.3-node
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -559,12 +559,12 @@ jobs:
       - run_php_cs
 
   unit-tests:
-    executor: php_74_apache_node_browser_mysql
+    executor: php_74_browsers_mysql
     steps:
       - run_php_unit_test
 
   theme-check:
-    executor: php_74_apache_node_browser_mysql
+    executor: php_74_browsers_mysql
     steps:
       - checkout
       - attach_workspace:
@@ -584,7 +584,7 @@ jobs:
           command: wp themecheck --theme=go --no-interactive --path=/var/www/html/wordpress
 
   customizer-e2e:
-    executor: php_74_apache_node_browser_mysql
+    executor: php_74_browsers_mysql
     steps:
       - run:
           name: Update hosts
@@ -646,7 +646,7 @@ jobs:
           command: ./node_modules/.bin/cypress run --browser chrome --parallel --record --spec .dev/tests/cypress/integration/customizer/*.js
 
   a11y-tests:
-    executor: php_74_apache_node_browser_mysql
+    executor: php_74_browsers_mysql
     steps:
       - checkout
       - attach_workspace:
@@ -675,7 +675,7 @@ jobs:
             fi
 
   i18n:
-    executor: php_74_node_browser_legacy
+    executor: php_74_browsers
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -710,35 +710,35 @@ jobs:
             git push origin master --quiet
 
   visual-regression-chrome:
-    executor: php_74_apache_node_browser_mysql
+    executor: php_74_browsers_mysql
     parallelism: 30
     steps:
       - run_visual_regression_tests:
           browser: chrome
 
   visual-regression-firefox:
-    executor: php_74_apache_node_browser_mysql
+    executor: php_74_browsers_mysql
     parallelism: 30
     steps:
       - run_visual_regression_tests:
           browser: firefox
 
   visual-regression-update-snapshots-chrome:
-    executor: python_node_browsers
+    executor: python_310_browsers
     parallelism: 30
     steps:
       - visual-regression-update-snapshots:
           browser: chrome
 
   visual-regression-update-snapshots-firefox:
-    executor: python_node_browsers
+    executor: python_310_browsers
     parallelism: 30
     steps:
       - visual-regression-update-snapshots:
           browser: firefox
 
   canary:
-    executor: go_node_browsers_legacy
+    executor: go_1_17_browsers
     steps:
       - checkout
       - attach_workspace:
@@ -771,7 +771,7 @@ jobs:
           path: /tmp/artifacts
 
   deploy:
-    executor: go_node_browsers_legacy
+    executor: go_1_17_browsers
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,33 +7,21 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWOR
-  php_73:
+  php_74:
     docker:
-      - image: circleci/php:7.3.31
+      - image: circleci/php:7.4.30
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
   php_80:
     docker:
-      - image: cimg/php:8.0
+      - image: circleci/php:8.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
   php_73_node_browser_legacy:
      docker:
-      - image: circleci/php:7.3-node-browsers-legacy
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-  php_73_apache_node_browser_mysql:
-    docker:
-      - image: circleci/php:7.3.31-apache-node-browsers
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-        environment:
-          XDEBUG_MODE=coverage
-      - image: circleci/mysql:5.7-ram
+      - image: circleci/php:7.4-node-browsers-legacy
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,9 @@ commands:
       - install_wpcli
       - run:
           name: Setup WordPress site
-          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: |
+            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages
@@ -387,7 +389,9 @@ commands:
       - install_wpcli
       - run:
           name: Setup WordPress site
-          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: |
+            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages
@@ -585,7 +589,9 @@ jobs:
       - install_wpcli
       - run:
           name: Setup WordPress site and install the Theme Check package
-          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: |
+            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Run theme check
           command: wp themecheck --theme=go --no-interactive --path=/var/www/html/wordpress
@@ -609,7 +615,9 @@ jobs:
             sudo apt-get install mariadb-client
       - run:
           name: Setup WordPress site
-          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: |
+            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages
@@ -673,7 +681,9 @@ jobs:
       - install_wpcli
       - run:
           name: Setup WordPress site
-          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: |
+            sudo docker-php-ext-install gd sockets mysqli exif imagick ssh2
+            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Run a11y tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,6 +606,8 @@ jobs:
       - run:
           name: Install Apache
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9
             sudo apt-get update && sudo apt-get install -y apache2
       - run:
           name: Setup WordPress site

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 
+
 orbs:
   browser-tools: circleci/browser-tools@1.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-  php_73_node_browser_legacy:
+  php_74_node_browser_legacy:
      docker:
       - image: circleci/php:7.4-node-browsers-legacy
         auth:
@@ -122,7 +122,7 @@ workflows:
             branches:
               ignore:
                 - actions/visual-regression-update-snapshots
-      - php73-phpcs: # Will be deprecated on 30 Nov 2020
+      - php74-phpcs:
           filters:
             tags:
               only: /^(?!canary).*$/
@@ -176,7 +176,7 @@ workflows:
       - canary:
           requires:
             - php56-phpcs
-            - php73-phpcs
+            - php74-phpcs
             - unit-tests
             - theme-check
             - a11y-tests
@@ -188,7 +188,7 @@ workflows:
       - deploy:
           requires:
             - php56-phpcs
-            - php73-phpcs
+            - php74-phpcs
             - unit-tests
             - theme-check
             - a11y-tests
@@ -548,8 +548,8 @@ jobs:
     steps:
       - run_php_cs
 
-  php73-phpcs:
-    executor: php_73
+  php74-phpcs:
+    executor: php_74
     steps:
       - run_php_cs
   
@@ -559,12 +559,12 @@ jobs:
       - run_php_cs
 
   unit-tests:
-    executor: php_73_apache_node_browser_mysql
+    executor: php_74_apache_node_browser_mysql
     steps:
       - run_php_unit_test
 
   theme-check:
-    executor: php_73_apache_node_browser_mysql
+    executor: php_74_apache_node_browser_mysql
     steps:
       - checkout
       - attach_workspace:
@@ -584,7 +584,7 @@ jobs:
           command: wp themecheck --theme=go --no-interactive --path=/var/www/html/wordpress
 
   customizer-e2e:
-    executor: php_73_apache_node_browser_mysql
+    executor: php_74_apache_node_browser_mysql
     steps:
       - run:
           name: Update hosts
@@ -646,7 +646,7 @@ jobs:
           command: ./node_modules/.bin/cypress run --browser chrome --parallel --record --spec .dev/tests/cypress/integration/customizer/*.js
 
   a11y-tests:
-    executor: php_73_apache_node_browser_mysql
+    executor: php_74_apache_node_browser_mysql
     steps:
       - checkout
       - attach_workspace:
@@ -675,7 +675,7 @@ jobs:
             fi
 
   i18n:
-    executor: php_73_node_browser_legacy
+    executor: php_74_node_browser_legacy
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -710,14 +710,14 @@ jobs:
             git push origin master --quiet
 
   visual-regression-chrome:
-    executor: php_73_apache_node_browser_mysql
+    executor: php_74_apache_node_browser_mysql
     parallelism: 30
     steps:
       - run_visual_regression_tests:
           browser: chrome
 
   visual-regression-firefox:
-    executor: php_73_apache_node_browser_mysql
+    executor: php_74_apache_node_browser_mysql
     parallelism: 30
     steps:
       - run_visual_regression_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,7 @@ jobs:
             sudo apt-get update && sudo apt-get install -y apache2
       - run:
           name: Setup WordPress site
-          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: sudo bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,7 @@ jobs:
       - run:
           name: Install MariaDB
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install mariadb-client
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   php_74_apache_node_browsers_mysql:
     docker:
-      - image: circleci/php:7.4-apache-node-browsers-legacy
+      - image: circleci/php:7.4-apache-node-browsers
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -336,9 +336,7 @@ commands:
       - install_wpcli
       - run:
           name: Setup WordPress site
-          command: |
-            sudo docker-php-ext-install gd sockets mysqli exif
-            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages
@@ -389,9 +387,7 @@ commands:
       - install_wpcli
       - run:
           name: Setup WordPress site
-          command: |
-            sudo docker-php-ext-install gd sockets mysqli exif
-            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages
@@ -589,9 +585,7 @@ jobs:
       - install_wpcli
       - run:
           name: Setup WordPress site and install the Theme Check package
-          command: |
-            sudo docker-php-ext-install gd sockets mysqli exif
-            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Run theme check
           command: wp themecheck --theme=go --no-interactive --path=/var/www/html/wordpress
@@ -615,10 +609,7 @@ jobs:
             sudo apt-get install mariadb-client
       - run:
           name: Setup WordPress site
-          command: |
-            sudo apt-get install libpng-dev
-            sudo docker-php-ext-install gd sockets mysqli exif
-            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache
       - run:
           name: Install Composer packages
@@ -682,9 +673,7 @@ jobs:
       - install_wpcli
       - run:
           name: Setup WordPress site
-          command: |
-            sudo docker-php-ext-install gd sockets mysqli exif
-            bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+          command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - run:
           name: Run a11y tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.1
+
 executors:
   php_56:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
           password: $DOCKERHUB_PASSWOR
   php_74:
     docker:
-      - image: circleci/php:7.4.30
+      - image: circleci/php:7.4
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,6 +604,10 @@ jobs:
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install mariadb-client
       - run:
+          name: Install Apache
+          command: |
+            sudo apt-get update && sudo apt-get install -y apache2
+      - run:
           name: Setup WordPress site
           command: bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -616,6 +616,7 @@ jobs:
       - run:
           name: Setup WordPress site
           command: |
+            sudo apt-get install libpng-dev
             sudo docker-php-ext-install gd sockets mysqli exif
             bash .dev/deploy-scripts/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
       - restore_composer_cache

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -108,7 +108,7 @@ setup_wp() {
 		--path=$WP_CORE_DIR \
 		--allow-root
 
-	wp db create --path=$WP_CORE_DIR
+	wp db create --path=$WP_CORE_DIR --allow-root
 	wp core install \
 		--url=http://go.test \
 		--title="WordPress Site" \
@@ -116,9 +116,10 @@ setup_wp() {
 		--admin_password=password \
 		--admin_email=admin@go.test \
 		--skip-email \
-		--path=$WP_CORE_DIR
+		--path=$WP_CORE_DIR \
+		--allow-root
 
-	wp option set permalink_structure "/%postname%/" --path=$WP_CORE_DIR
+	wp option set permalink_structure "/%postname%/" --path=$WP_CORE_DIR --allow-root
 }
 
 install_test_suite() {

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -96,11 +96,12 @@ install_wp() {
 	fi
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+
+	sudo apt-get install libpng-dev
+    sudo docker-php-ext-install gd sockets mysqli exif
 }
 
 setup_wp() {
-	wp package install git@github.com:johnbillion/ext.git
-	wp ext required
 	wp config create \
 		--dbname=wordpress \
 		--dbuser=$DB_USER \
@@ -117,8 +118,7 @@ setup_wp() {
 		--admin_password=password \
 		--admin_email=admin@go.test \
 		--skip-email \
-		--path=$WP_CORE_DIR \
-		--debug
+		--path=$WP_CORE_DIR
 
 	wp option set permalink_structure "/%postname%/" --path=$WP_CORE_DIR
 }

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -100,7 +100,7 @@ install_wp() {
 
 setup_wp() {
 	wp package install git@github.com:johnbillion/ext.git
-	wp ext check
+	wp ext required
 	wp config create \
 		--dbname=wordpress \
 		--dbuser=$DB_USER \

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -98,7 +98,7 @@ install_wp() {
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 
 	sudo apt-get install libpng-dev
-    sudo docker-php-ext-install gd sockets mysqli exif
+	sudo docker-php-ext-install gd sockets mysqli exif
 }
 
 setup_wp() {

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -7,7 +7,7 @@ fi
 
 sudo apt-get update && sudo apt-get install subversion
 sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
-sudo apt-get update && sudo apt-get install mysql-client-5.7
+sudo apt-get update && sudo apt-get install default-mysql-client
 
 DB_NAME=$1
 DB_USER=$2

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -6,7 +6,6 @@ if [ $# -lt 3 ]; then
 fi
 
 sudo apt-get update && sudo apt-get install subversion
-sudo -E docker-php-ext-install mysqli
 sudo sh -c "printf '\ndeb http://ftp.us.debian.org/debian sid main\n' >> /etc/apt/sources.list"
 sudo apt-get update && sudo apt-get install mysql-client-5.7
 

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -115,7 +115,8 @@ setup_wp() {
 		--admin_password=password \
 		--admin_email=admin@go.test \
 		--skip-email \
-		--path=$WP_CORE_DIR 
+		--path=$WP_CORE_DIR \
+		--debug
 
 	wp option set permalink_structure "/%postname%/" --path=$WP_CORE_DIR
 }

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -105,7 +105,8 @@ setup_wp() {
 		--dbpass=$DB_PASS \
 		--dbhost=$DB_HOST \
 		--skip-check \
-		--path=$WP_CORE_DIR
+		--path=$WP_CORE_DIR \
+		--allow-root
 
 	wp db create --path=$WP_CORE_DIR
 	wp core install \

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -99,6 +99,8 @@ install_wp() {
 }
 
 setup_wp() {
+	wp package install git@github.com:johnbillion/ext.git
+	wp ext check
 	wp config create \
 		--dbname=wordpress \
 		--dbuser=$DB_USER \

--- a/.dev/deploy-scripts/install-wp-tests.sh
+++ b/.dev/deploy-scripts/install-wp-tests.sh
@@ -105,10 +105,9 @@ setup_wp() {
 		--dbpass=$DB_PASS \
 		--dbhost=$DB_HOST \
 		--skip-check \
-		--path=$WP_CORE_DIR \
-		--allow-root
+		--path=$WP_CORE_DIR
 
-	wp db create --path=$WP_CORE_DIR --allow-root
+	wp db create --path=$WP_CORE_DIR
 	wp core install \
 		--url=http://go.test \
 		--title="WordPress Site" \
@@ -116,10 +115,9 @@ setup_wp() {
 		--admin_password=password \
 		--admin_email=admin@go.test \
 		--skip-email \
-		--path=$WP_CORE_DIR \
-		--allow-root
+		--path=$WP_CORE_DIR 
 
-	wp option set permalink_structure "/%postname%/" --path=$WP_CORE_DIR --allow-root
+	wp option set permalink_structure "/%postname%/" --path=$WP_CORE_DIR
 }
 
 install_test_suite() {


### PR DESCRIPTION
* Replace `PHP:7.3` images with `PHP:7.4` images

* Move away from using CircleCI legacy images (`circleci/` to `cimg/`).
  * Does not include `php_74_apache_node_browsers_mysql`
 
* Ensure tests are passing after updates
