### PR TITLE
Update theme.json to include content widths

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -3,8 +3,8 @@
 	"settings": {
 		"appearanceTools": true,
 		"layout": {
-			"contentSize": "800px",
-			"wideSize": "1000px"
+			"contentSize": "--go--max-width",
+			"wideSize": "--go--max-width--alignwide"
 		}
 	}
 }

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,10 @@
 {
 	"version": 2,
 	"settings": {
-		"appearanceTools": true
+		"appearanceTools": true,
+		"layout": {
+			"contentSize": "800px",
+			"wideSize": "1000px"
+		}
 	}
 }


### PR DESCRIPTION
This change allows alignment controls in the editor again. The width values seem a bit arbitrary. Should we change them from the current proposed values?

See:
https://make.wordpress.org/core/2021/06/29/on-layout-and-content-width-in-wordpress-5-8/
https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/

Fixes #798 