### PR TITLE
Fix customizer-e2e CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,7 +558,7 @@ jobs:
     executor: php_74
     steps:
       - run_php_cs
-  
+
   php80-phpcs:
     executor: php_80
     steps:
@@ -648,7 +648,7 @@ jobs:
             wp plugin activate woocommerce --path=/var/www/html/wordpress
       - run:
           name: Setup the Keynote template
-          command: wp nux import keynote --path=/var/www/html/wordpress
+          command: wp nux import keynote --path=/var/www/html/wordpress --content-only
       - run:
           name: "Run end to end Customizer tests (Cypress.io) - chrome"
           command: ./node_modules/.bin/cypress run --browser chrome --parallel --record --spec .dev/tests/cypress/integration/customizer/*.js


### PR DESCRIPTION
The `customizer-e2e` job is currently failing because it is attempting to update Go. When we are working on a new release, the version of Go is higher than what is on WordPress.org, and WPCLI throws an error and the build fails. Since we are already manually installing CoBlocks, WooCommerce and Go - we shouldn't rely on wpnux command to install or update any of these.

I've added a `--content-only` flag when setting up the template, which stops the plugins and themes from being installed/updated.