### PR TITLE
Style Overrides to fix full width alignment in the editor.

### DIFF
--- a/.dev/assets/shared/css/style-editor.scss
+++ b/.dev/assets/shared/css/style-editor.scss
@@ -27,8 +27,8 @@ body {
 
 // Add negative padding on fullwidth blocks.
 .block-editor-block-list__layout.is-root-container > .wp-block[data-align="full"] {
-	margin-left: calc(-1 * var(--go-block--padding--x));
-	margin-right: calc(-1 * var(--go-block--padding--x));
+	margin-left: calc(-1 * var(--go-block--padding--x)) !important;
+	margin-right: calc(-1 * var(--go-block--padding--x)) !important;
 }
 
 // Default appender
@@ -45,7 +45,6 @@ body.block-editor-block-preview__container {
 
 // Block Editor Insert Panel Fix
 body.block-editor-inserter__panel-content {
-
 	.wp-block[data-align="full"],
 	.wp-block[data-align="wide"] {
 		margin-bottom: 0 !important;


### PR DESCRIPTION
Due to some existing core styles setting auto margins on important we do not have a full alignment within the editor. Style changes here force the editor to match the front-end when it comes to full alignment. 