### PR TITLE
Try a higher timeout for Pa11y tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ commands:
             sudo chmod -R 777 ../../
             mkdir -p ../../plugins/coblocks
             if [ "$CIRCLE_JOB" == "php56-phpcs" ]; then
-              rm vendor/composer/installed.json
+              rm -f vendor/composer/installed.json
               composer require oomphinc/composer-installers-extender ^1.1
             fi
             composer install

--- a/.dev/tests/accessibility/compliance/pa11y.js
+++ b/.dev/tests/accessibility/compliance/pa11y.js
@@ -49,7 +49,7 @@ const config = {
 	includeWarnings: true,
 	rootElement: 'body',
 	threshold: 2,
-	timeout: 20000,
+	timeout: 300000,
 	userAgent: 'pa11y',
 	width: 1280,
 	ignore: [


### PR DESCRIPTION
The a11y-tests are failing in CircleCI, due to a timeout. Let's increase that timeout to see if we can get some more information about the test failures. 