### PR TITLE
Use -f option on rm to avoid error exits.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ commands:
             sudo chmod -R 777 ../../
             mkdir -p ../../plugins/coblocks
             if [ "$CIRCLE_JOB" == "php56-phpcs" ]; then
-              rm vendor/composer/installed.json
+              rm -f vendor/composer/installed.json
               composer require oomphinc/composer-installers-extender ^1.1
             fi
             composer install


### PR DESCRIPTION
When using `rm` to remove files and directories, a not-found file or directory will cause the process to error exit, preventing the process from continuing. Adding the `-f` option flag ensures that, if the file or directory does not exist, it will not error exit, allowing the process continues without error.

While you will not always want to pass this, in this case it is warranted. 

Note: This is the cause of the error in #804, but we may need to investigate further if Composer is installing everything correctly on that test.