### PR TITLE
Bump 'Tested up to' to WP 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 		<img src="https://img.shields.io/circleci/build/github/godaddy-wordpress/go/master?label=&logo=circleci&style=flat-square" alt="CircleCI Build">
 	</a>
 	<a href="https://wordpress.org/" target="_blank">
-		<img src="https://img.shields.io/static/v1?label=&message=5.0+-+6.0&color=blue&style=flat-square&logo=wordpress&logoColor=white" alt="WordPress Versions">
+		<img src="https://img.shields.io/static/v1?label=&message=5.0+-+6.1&color=blue&style=flat-square&logo=wordpress&logoColor=white" alt="WordPress Versions">
 	</a>
 	<a href="https://www.php.net/" target="_blank">
 		<img src="https://img.shields.io/static/v1?label=&message=7.4+-+8.0&color=777bb4&style=flat-square&logo=php&logoColor=white" alt="PHP Versions">

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: godaddy, richtabor, eherman24, jrtashjian
 Tags: block-styles, custom-colors, custom-logo, custom-menu, e-commerce, editor-style, one-column, theme-options, threaded-comments, translation-ready, wide-blocks
 Requires at least: 5.0
-Tested up to: 6.0
-Requires PHP: 5.6.0
+Tested up to: 6.1
+Requires PHP: 7.4
 Stable tag: 1.6.5
 License: GPL-2.0-only
 License URI: https://www.gnu.org/licenses/license-list.html#GPLv2


### PR DESCRIPTION
We're nearing the end of our modifications and tests for WP 6.1, so our next release will be tagged as supporting WP 6.1