### PR TITLE
Add label styles to site design stylesheets

### DIFF
--- a/.dev/assets/design-styles/playful/settings.scss
+++ b/.dev/assets/design-styles/playful/settings.scss
@@ -54,6 +54,7 @@
 	--go-label--font-weight: 600;
 	--go-label--letter-spacing: var(--go-navigation--letter-spacing, normal);
 	--go-label--margin-bottom: 0.35rem;
+	--go-label--text-transform: normal;
 
 	// Input
 	--go-input--border-radius: 5px;

--- a/.dev/assets/design-styles/traditional/settings.scss
+++ b/.dev/assets/design-styles/traditional/settings.scss
@@ -73,6 +73,7 @@
 	--go-label--font-weight: var(--go-navigation--font-weight, 400);
 	--go-label--letter-spacing: var(--go-navigation--letter-spacing, normal);
 	--go-label--margin-bottom: 0.25rem;
+	--go-label--text-transform: normal;
 
 	// Input
 	--go-input--border: var(--go-input--border-width, 2px) var(--go-input--border-style, solid) var(--go-input--border-color, var(--go-heading--color--text));


### PR DESCRIPTION
A simple change here for style consistency across styles.

This PR is related to CoBlocks PR here:
https://github.com/godaddy-wordpress/coblocks/pull/2442
