### PR TITLE
Skip the precommit verification.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Push changes
         run: |
           git add .
-          git commit -m "Updating to version $NEW_TAG_VERSION"
+          git commit -m "Updating to version $NEW_TAG_VERSION" --no-verify
           git push
 
   build:


### PR DESCRIPTION
Everything is already verified, so we can skip this step.