### PR TITLE
Fix variation product payment buttons on Safari and Chrome.

### DIFF
--- a/.dev/assets/shared/css/woocommerce/product.scss
+++ b/.dev/assets/shared/css/woocommerce/product.scss
@@ -118,7 +118,7 @@ table.variations tbody tr:nth-child(odd) {
 	}
 
 	&.value {
-		padding-bottom: 0.5rem;
+		padding: 0.5rem;
 	}
 }
 
@@ -131,7 +131,7 @@ table.variations tbody tr:nth-child(odd) {
 
 	.single_variation_wrap {
 
-		.woocommerce-variation-add-to-cart {
+		.woocommerce-variation-add-to-cart:not(.variations_button) {
 			align-items: center;
 			display: flex;
 			justify-content: center;


### PR DESCRIPTION
The layout should be vertical instead of horizontal. A simple change here on selectors and also alter padding of the select button for variations.

Example site setup here: https://i0c.872.myftpupload.com/product/example-variable-product/?attribute_size=Small

This page features the changes.