### PR TITLE
Introduce a script and a Github workflow to ensure our WooCommerce templates are always up to date with the latest version.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,6 +18,7 @@ checks:
   method-complexity:
     enabled: false
 exclude_patterns:
+  - ".dev/bin/"
   - ".dev/config/"
   - ".dev/deploy-scripts/"
   - ".dev/tests/"

--- a/.dev/bin/update-woo-template-versions.php
+++ b/.dev/bin/update-woo-template-versions.php
@@ -15,7 +15,12 @@ foreach ( new RecursiveIteratorIterator( $it ) as $file ) {
 
 	$template_dir = str_replace( './woocommerce/', '', $file );
 
-	$remote_template_contents = file_get_contents( sprintf( 'https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce/templates/%s', $template_dir ) );
+	$remote_template_contents = file_get_contents(
+		sprintf(
+			'https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce/templates/%s',
+			$template_dir
+		)
+	);
 
 	// Grab the version from the remote template.
 	preg_match( '/(?:@version)\s*((?:[0-9]+\.?)+)/i', $remote_template_contents, $matches );
@@ -55,7 +60,17 @@ foreach ( new RecursiveIteratorIterator( $it ) as $file ) {
 	// Update the version in the template file.
 	printf( 'Bundled template version is outdated (%1$s). Updating %2$s now.' . PHP_EOL, $bundled_woocommerce_template_version, $template_dir );
 
-	$new_file_contents = str_replace( sprintf( '@version %s', $bundled_woocommerce_template_version ), sprintf( '@version %s', $current_woocommerce_template_version ), $bundled_template_markup );
+	$new_file_contents = str_replace(
+		sprintf(
+			'@version %s',
+			$bundled_woocommerce_template_version
+		),
+		sprintf(
+			'@version %s',
+			$current_woocommerce_template_version
+		),
+		$bundled_template_markup
+	);
 
 	file_put_contents( $file, $new_file_contents );
 

--- a/.dev/bin/update-woo-template-versions.php
+++ b/.dev/bin/update-woo-template-versions.php
@@ -5,7 +5,7 @@
 $it = new RecursiveDirectoryIterator( './woocommerce' );
 
 // Loop through template files.
-foreach( new RecursiveIteratorIterator( $it ) as $file ) {
+foreach ( new RecursiveIteratorIterator( $it ) as $file ) {
 
 	if ( $file->getExtension() !== 'php' ) {
 
@@ -18,7 +18,7 @@ foreach( new RecursiveIteratorIterator( $it ) as $file ) {
 	$remote_template_contents = file_get_contents( sprintf( 'https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce/templates/%s', $template_dir ) );
 
 	// Grab the version from the remote template.
-	preg_match( "/(?:@version)\s*((?:[0-9]+\.?)+)/i", $remote_template_contents, $matches );
+	preg_match( '/(?:@version)\s*((?:[0-9]+\.?)+)/i', $remote_template_contents, $matches );
 
 	if ( empty( $matches ) ) {
 
@@ -33,7 +33,7 @@ foreach( new RecursiveIteratorIterator( $it ) as $file ) {
 	$bundled_template_markup = file_get_contents( $file );
 
 	// Grab the version from the bundled template.
-	preg_match( "/(?:@version)\s*((?:[0-9]+\.?)+)/i", $bundled_template_markup, $matches );
+	preg_match( '/(?:@version)\s*((?:[0-9]+\.?)+)/i', $bundled_template_markup, $matches );
 
 	if ( empty( $matches ) ) {
 

--- a/.dev/bin/update-woo-template-versions.php
+++ b/.dev/bin/update-woo-template-versions.php
@@ -1,0 +1,67 @@
+#!/usr/bin/env php
+<?php
+
+// Construct the iterator.
+$it = new RecursiveDirectoryIterator( './woocommerce' );
+
+// Loop through template files.
+foreach( new RecursiveIteratorIterator( $it ) as $file ) {
+
+	if ( $file->getExtension() !== 'php' ) {
+
+		continue;
+
+	}
+
+	$template_dir = str_replace( './woocommerce/', '', $file );
+
+	$remote_template_contents = file_get_contents( sprintf( 'https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce/templates/%s', $template_dir ) );
+
+	// Grab the version from the remote template.
+	preg_match( "/(?:@version)\s*((?:[0-9]+\.?)+)/i", $remote_template_contents, $matches );
+
+	if ( empty( $matches ) ) {
+
+		printf( 'No versions found in remote template file: %s.' . PHP_EOL, $template );
+
+		continue;
+
+	}
+
+	$current_woocommerce_template_version = $matches[1];
+
+	$bundled_template_markup = file_get_contents( $file );
+
+	// Grab the version from the bundled template.
+	preg_match( "/(?:@version)\s*((?:[0-9]+\.?)+)/i", $bundled_template_markup, $matches );
+
+	if ( empty( $matches ) ) {
+
+		printf( 'No versions found in bundled template file: %s.' . PHP_EOL, $template_dir );
+
+		continue;
+
+	}
+
+	$bundled_woocommerce_template_version = $matches[1];
+
+	if ( version_compare( $current_woocommerce_template_version, $bundled_woocommerce_template_version, '=' ) ) {
+
+		printf( 'Remote template and bundled template versions match: %s' . PHP_EOL, $template_dir );
+		exit;
+
+	}
+
+	// Update the version in the template file.
+	printf( 'Bundled template version is outdated (%1$s). Updating %2$s now.' . PHP_EOL, $bundled_woocommerce_template_version, $template_dir );
+
+	$new_file_contents = str_replace( sprintf( '@version %s', $bundled_woocommerce_template_version ), sprintf( '@version %s', $current_woocommerce_template_version ), $bundled_template_markup );
+
+	file_put_contents( $file, $new_file_contents );
+
+	printf( sprintf( 'Updated %s.' . PHP_EOL, $template_dir ) );
+
+}
+
+print( 'Done.' . PHP_EOL );
+exit;

--- a/.github/workflows/bump-woo-template-versions.yml
+++ b/.github/workflows/bump-woo-template-versions.yml
@@ -1,0 +1,40 @@
+name: Update WooCommerce Template Versions
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update:
+    name: Update Translations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "godaddy-wordpress-bot"
+          git config --global user.email "plugins@godaddy.com"
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Update the WooCommerce template files
+        run: .dev/bin/update-woo-template-versions.php
+
+      - name: Commit changes
+        shell: bash
+        run: |
+          if [ ! -z "$(git status woocommerce/* --porcelain)" ]; then
+            git add woocommerce/*
+            git commit -m "[BOT] Update WooCommerce template versions." --no-verify
+            git reset --hard
+            git push --quiet
+          else
+            echo "No WooCommerce template versions to update."
+          fi

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "test:js:coverage": "yarn test:js --coverage",
     "test:js:update": "yarn test:js -u",
     "prepare": "husky install .dev/husky",
-    "wp-env": "wp-env"
+    "wp-env": "wp-env",
+    "update:woo-template-versions": ".dev/bin/update-woo-template-versions.php"
   },
   "locales": {
     "ar": "العربية",

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 7.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.4.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
Introduce a way to automate the process of keeping the WooCommerce cart.php template files version, that we bundle, up to date. This script reaches out to the WooCommerce template file on Github and compares our bundled template version to the most up to date one. If the version on the WooCommerce github is greater than the one we bundle, our Github workflow will bump the version in the bundled template and commit it back to Github, ensuring that our template version always matches the most up to date one on [Github](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/templates).

- The script can be run locally with `npm run update:woo-template-versions`.
- The script will run on any commits into `master` via [this workflow](https://github.com/godaddy-wordpress/go/pull/847/files#diff-c8ffdf393c0c7fca38f0c86f5ee054bdc4f57947b291bdc5fcfc25a5998a50b5R1-R40), update the template file (if needed) and then commit the updated file back to Github.