### PR TITLE
Bump cart.php version

### DIFF
--- a/.dev/tests/php/test-functions.php
+++ b/.dev/tests/php/test-functions.php
@@ -28,7 +28,7 @@ class Test_Functions extends WP_UnitTestCase {
 	 */
 	function testVersionDefined() {
 
-		$this->assertEquals( '1.8.1', GO_VERSION );
+		$this->assertEquals( '1.8.2', GO_VERSION );
 
 	}
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Go <a href="https://github.com/godaddy-wordpress/go/releases/latest/"><img src="https://img.shields.io/static/v1?goVersion=&message=v1.8.0&label=&color=999&style=flat-square"></a></h1>
+<h1 align="center">Go <a href="https://github.com/godaddy-wordpress/go/releases/latest/"><img src="https://img.shields.io/static/v1?goVersion=&message=v1.8.2&label=&color=999&style=flat-square"></a></h1>
 
 <h4 align="center">The most flexible <a href="https://github.com/wordpress/gutenberg" target="_blank">Gutenberg</a>-first <a href="https://wordpress.org" target="_blank">WordPress</a> theme built for go-getters everywhere.</h4>
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+= 1.8.2 / 2023-06-23 =
+### Updates
+- Bump the WooCommerce `cart.php` template version to `7.8.0`.
+
 1.8.1 / 2023-03-24
 - Modify styles for CoBlocks 3.0. [#838](https://github.com/godaddy-wordpress/go/pull/838)
 - Introduce a script and a Github workflow to ensure our WooCommerce templates are always up to date with the latest version. [#847](https://github.com/godaddy-wordpress/go/pull/847)

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@
 /**
  * Theme constants.
  */
-define( 'GO_VERSION', '1.8.1' );
+define( 'GO_VERSION', '1.8.2' );
 define( 'GO_PLUGIN_DIR', get_template_directory( __FILE__ ) );
 define( 'GO_PLUGIN_URL', get_template_directory_uri( __FILE__ ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Go is an innovative, Gutenberg-first WordPress theme, hyper-focused on empowering makers to build beautifully rich websites with WordPress.",
   "homepage": "https://github.com/godaddy-wordpress/go",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: block-styles, custom-colors, custom-logo, custom-menu, e-commerce, editor-
 Requires at least: 5.0
 Tested up to: 6.2
 Requires PHP: 7.4
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPL-2.0-only
 License URI: https://www.gnu.org/licenses/license-list.html#GPLv2
 
@@ -108,9 +108,6 @@ List of bespoke icons:
 - Comments icon
 
 == Changelog ==
-= 1.6.6 / 2022-11-03 =
+= 1.8.2 / 2023-06-23 =
 ### Updates
-- Bump 'Tested Up To' Version to 6.1. [#818](https://github.com/godaddy-wordpress/go/pull/818)
-- Update WooCommerce cart.php template version. [#817](https://github.com/godaddy-wordpress/go/pull/817)
-- Add label styles to site design stylesheets. [#814](https://github.com/godaddy-wordpress/go/pull/814)
-- Drop support for PHP 5.6. [#811](https://github.com/godaddy-wordpress/go/pull/811)
+- Bump the WooCommerce `cart.php` template version to `7.8.0`.

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Description:  Go is an innovative, Gutenberg-first WordPress theme, hyper-focused on empowering makers to build beautifully rich websites with WordPress.
  * Author:       GoDaddy
  * Author URI:   https://www.godaddy.com
- * Version:      1.8.1
+ * Version:      1.8.2
  * Tested up to: 6.2
  * Requires PHP: 7.4
  * License:      GPL-2.0

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.4.0
+ * @version 7.8.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
- Bump version of theme to `1.8.2`.
- Bump WooCommerce cart.php template to `7.8.0`.