### PR TITLE
Add cover styles with filter contrast

### DIFF
--- a/.dev/assets/shared/css/blocks/cover/_style.scss
+++ b/.dev/assets/shared/css/blocks/cover/_style.scss
@@ -60,4 +60,8 @@
 			justify-content: center;
 		}
 	}
+
+	&.has-image-filter-contrast .wp-block-cover__background {
+		filter: contrast(0.3);
+	}
 }


### PR DESCRIPTION
Introduce styles specific to Cover block used with Go theme. This style applies `filter: contrast(0.3)` to the classname `has-image-filter-contrast`.