### PR TITLE
Re-add the original go_avaliable_social_icons filter

### DIFF
--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -1053,14 +1053,14 @@ class Test_Core extends WP_UnitTestCase {
 	function testGetAvailableSocialIconsFilter() {
 
 		$test_data = [
-			'label'       => 'Test',
+			'label'       => 'Test New',
 			'icon'        => 'icon',
 			'placeholder' => 'placeholder',
 		];
 
 		add_filter( 'go_available_social_icons', function( $social_icons ) use( $test_data ) {
 
-			$social_icons['test'] = $test_data;
+			$social_icons['test_new'] = $test_data;
 
 			return $social_icons;
 
@@ -1068,7 +1068,7 @@ class Test_Core extends WP_UnitTestCase {
 
 		$social_icons = Go\Core\get_available_social_icons();
 
-		$this->assertEquals( $test_data, $social_icons['test'] );
+		$this->assertEquals( $test_data, $social_icons['test_new'] );
 
 	}
 

--- a/.dev/tests/php/test-core.php
+++ b/.dev/tests/php/test-core.php
@@ -1023,7 +1023,32 @@ class Test_Core extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test filtering the social icons
+	 * Test filtering the social icons with the go_avaliable_social_icons filter (old filter name with typo).
+	 */
+	function testGetAvaliableSocialIconsFilter() {
+
+		$test_data = [
+			'label'       => 'Test',
+			'icon'        => 'icon',
+			'placeholder' => 'placeholder',
+		];
+
+		add_filter( 'go_avaliable_social_icons', function( $social_icons ) use( $test_data ) {
+
+			$social_icons['test'] = $test_data;
+
+			return $social_icons;
+
+		} );
+
+		$social_icons = Go\Core\get_available_social_icons();
+
+		$this->assertEquals( $test_data, $social_icons['test'] );
+
+	}
+
+	/**
+	 * Test filtering the social icons with the go_available_social_icons filter.
 	 */
 	function testGetAvailableSocialIconsFilter() {
 
@@ -1033,7 +1058,7 @@ class Test_Core extends WP_UnitTestCase {
 			'placeholder' => 'placeholder',
 		];
 
-		add_filter( 'go_avaliable_social_icons', function( $social_icons ) use( $test_data ) {
+		add_filter( 'go_available_social_icons', function( $social_icons ) use( $test_data ) {
 
 			$social_icons['test'] = $test_data;
 

--- a/includes/core.php
+++ b/includes/core.php
@@ -1269,8 +1269,8 @@ function get_available_social_icons() {
 	 *
 	 * @param array $social_icons Array containing the supported social icons.
 	 *
-	 * There is a double filter here to maintain backwards compatibility after fixing a typo in the name of the filter.
-	 * See: https://github.com/godaddy-wordpress/go/pull/870/files#diff-21e944aca0f42ff6529bde979b0fd787d00e010406e6642f947e71bf5e6f5ad1L1272-R1272
+	 * Note: There is a double filter here to maintain backwards compatibility after fixing a typo in the name of the filter.
+	 * @see https://github.com/godaddy-wordpress/go/pull/870/files#diff-21e944aca0f42ff6529bde979b0fd787d00e010406e6642f947e71bf5e6f5ad1L1272-R1272
 	 */
 	return (array) apply_filters( 'go_available_social_icons', apply_filters( 'go_avaliable_social_icons', $social_icons ) );
 

--- a/includes/core.php
+++ b/includes/core.php
@@ -1268,8 +1268,11 @@ function get_available_social_icons() {
 	 * @since 0.1.0
 	 *
 	 * @param array $social_icons Array containing the supported social icons.
+	 *
+	 * There is a double filter here to maintain backwards compatibility after fixing a typo in the name of the filter.
+	 * See: https://github.com/godaddy-wordpress/go/pull/870/files#diff-21e944aca0f42ff6529bde979b0fd787d00e010406e6642f947e71bf5e6f5ad1L1272-R1272
 	 */
-	return (array) apply_filters( 'go_available_social_icons', $social_icons );
+	return (array) apply_filters( 'go_available_social_icons', apply_filters( 'go_avaliable_social_icons', $social_icons ) );
 
 }
 


### PR DESCRIPTION
Re-adding the original filter (with a typo) to maintain backwards compatibility after the name of the filter was updated in a previous PR.
https://github.com/godaddy-wordpress/go/pull/870/files#diff-21e944aca0f42ff6529bde979b0fd787d00e010406e6642f947e71bf5e6f5ad1L1272-R1272