### PR TITLE
Adjust cover block image contrast on CaaS sites only

### DIFF
--- a/.dev/assets/shared/css/blocks/cover/_style.scss
+++ b/.dev/assets/shared/css/blocks/cover/_style.scss
@@ -60,8 +60,4 @@
 			justify-content: center;
 		}
 	}
-
-	&.has-image-filter-contrast .wp-block-cover__image-background {
-		filter: contrast(0.3);
-	}
 }

--- a/includes/core.php
+++ b/includes/core.php
@@ -475,6 +475,20 @@ function styles() {
 		GO_VERSION
 	);
 
+	$wpnux_export_data = json_decode( get_option( 'wpnux_export_data', '{}' ), true );
+
+	if ( isset( $wpnux_export_data['_meta']['content_id'] ) ) {
+
+		$caas_cover_block_contrast_adjustmnet = '
+			.wp-block-cover.has-image-filter-contrast .wp-block-cover__image-background {
+				filter: contrast(0.3);
+			}
+		';
+
+		wp_add_inline_style( 'go-style', $caas_cover_block_contrast_adjustmnet );
+
+	}
+
 	$design_style = get_design_style();
 
 	if ( $design_style ) {


### PR DESCRIPTION
Remove the cover block filter from all sites and only apply them to CaaS sites.