### PR TITLE
Bump tested up to value to 6.4

### DIFF
--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -784,7 +784,7 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		$this->initialize_woo_session();
 
-		$this->expectOutputRegex( '/<div class="product-navigation-wrapper">\\n(\s*)<a href="(.*)" class="back-to-shop">Back<\/a>(\s*)<\/div>/' );
+		$this->expectOutputRegex( sprintf( '/<div class="product-navigation-wrapper">\\n(\s*)<nav class="woocommerce-breadcrumb" aria-label="Breadcrumb">Shop Page<\/nav><a href="http:\/\/localhost:8889\/\?page_id=%s" class="back-to-shop">/', get_option( 'woocommerce_shop_page_id' ) ) );
 
 		Go\WooCommerce\single_product_header();
 

--- a/.dev/tests/php/test-woocommerce.php
+++ b/.dev/tests/php/test-woocommerce.php
@@ -784,7 +784,7 @@ class Test_WooCommerce extends WP_UnitTestCase {
 
 		$this->initialize_woo_session();
 
-		$this->expectOutputRegex( sprintf( '/<div class="product-navigation-wrapper">\\n(\s*)<nav class="woocommerce-breadcrumb">Shop Page<\/nav><a href="http:\/\/localhost:8889\/\?page_id=%s" class="back-to-shop">/', get_option( 'woocommerce_shop_page_id' ), get_option( 'woocommerce_shop_page_id' ) ) );
+		$this->expectOutputRegex( '/<div class="product-navigation-wrapper">\\n(\s*)<a href="(.*)" class="back-to-shop">Back<\/a>(\s*)<\/div>/' );
 
 		Go\WooCommerce\single_product_header();
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Go <a href="https://github.com/godaddy-wordpress/go/releases/latest/"><img src="https://img.shields.io/static/v1?goVersion=&message=v1.8.4&label=&color=999&style=flat-square"></a></h1>
+<h1 align="center">Go <a href="https://github.com/godaddy-wordpress/go/releases/latest/"><img src="https://img.shields.io/static/v1?goVersion=&message=v1.8.7&label=&color=999&style=flat-square"></a></h1>
 
 <h4 align="center">The most flexible <a href="https://github.com/wordpress/gutenberg" target="_blank">Gutenberg</a>-first <a href="https://wordpress.org" target="_blank">WordPress</a> theme built for go-getters everywhere.</h4>
 
@@ -9,7 +9,7 @@
 		<img src="https://github.com/godaddy-wordpress/go/actions/workflows/run-tests.yml/badge.svg" alt="Github Test Workflow">
 	</a>
 	<a href="https://wordpress.org/" target="_blank">
-		<img src="https://img.shields.io/static/v1?label=&message=5.0+-+6.3&color=blue&style=flat-square&logo=wordpress&logoColor=white" alt="WordPress Versions">
+		<img src="https://img.shields.io/static/v1?label=&message=5.0+-+6.4&color=blue&style=flat-square&logo=wordpress&logoColor=white" alt="WordPress Versions">
 	</a>
 	<a href="https://www.php.net/" target="_blank">
 		<img src="https://img.shields.io/static/v1?label=&message=7.4+-+8.2&color=777bb4&style=flat-square&logo=php&logoColor=white" alt="PHP Versions">

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,14 @@
+= 1.8.7 / 2023-08-08 =
+- Bump the tested up to version to 6.4. [#899](https://github.com/godaddy-wordpress/go/pull/899)
+
 = 1.8.6 / 2023-08-08 =
-- Bump the tested up to version to 6.3. [896](https://github.com/godaddy-wordpress/go/pull/896)
+- Bump the tested up to version to 6.3. [#896](https://github.com/godaddy-wordpress/go/pull/896)
 
 = 1.8.5 / 2023-07-18 =
-- Introduce cover styles for image contrast filters. [884](https://github.com/godaddy-wordpress/go/pull/884)
-- Introduce filter fallbacks for typo updates. [889](https://github.com/godaddy-wordpress/go/pull/889)
-- Fix typos in code and filter. [882](https://github.com/godaddy-wordpress/go/pull/882) [870](https://github.com/godaddy-wordpress/go/pull/870)
-- Misc software bumps. [881](https://github.com/godaddy-wordpress/go/pull/881)[880](https://github.com/godaddy-wordpress/go/pull/880)
+- Introduce cover styles for image contrast filters. [#884](https://github.com/godaddy-wordpress/go/pull/884)
+- Introduce filter fallbacks for typo updates. [#889](https://github.com/godaddy-wordpress/go/pull/889)
+- Fix typos in code and filter. [#882](https://github.com/godaddy-wordpress/go/pull/882) [870](https://github.com/godaddy-wordpress/go/pull/870)
+- Misc software bumps. [#881](https://github.com/godaddy-wordpress/go/pull/881)[880](https://github.com/godaddy-wordpress/go/pull/880)
 
 = 1.8.4 / 2023-06-28 =
 - Fix layout of the WooCommerce block grid inside of a vertical group block. [#878](https://github.com/godaddy-wordpress/go/pull/878)

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: godaddy, richtabor, eherman24, jrtashjian, kopepasah, olivierlafleur
 Tags: block-styles, custom-colors, custom-logo, custom-menu, e-commerce, editor-style, one-column, theme-options, threaded-comments, translation-ready, wide-blocks
 Requires at least: 5.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Stable tag: 1.8.6
 License: GPL-2.0-only
@@ -38,7 +38,7 @@ You can fork and contribute back to Go by visiting [our public repo on GitHub](h
 
 == Copyright ==
 
-Go WordPress theme, Copyright 2019 GoDaddy Operating Company, LLC.
+Go WordPress theme, Copyright 2023 GoDaddy Operating Company, LLC.
 Go is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@
  * Author:       GoDaddy
  * Author URI:   https://www.godaddy.com
  * Version:      1.8.6
- * Tested up to: 6.3
+ * Tested up to: 6.4
  * Requires PHP: 5.6
  * License:      GPL-2.0
  * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
@@ -17,6 +17,6 @@
  * This theme, like WordPress, is licensed under the GPL.
  * Use it to make something cool, have fun, and share what you've learned with others.
  *
- * Copyright © 2019 GoDaddy Operating Company, LLC. All Rights Reserved.
+ * Copyright © 2023 GoDaddy Operating Company, LLC. All Rights Reserved.
  */
 /* stylelint-enable */


### PR DESCRIPTION
WordPress 6.4 - Release Slated for November 7th, 2023.