### PR TITLE
Fix incorrect width on Trendy style button arrow

### DIFF
--- a/.dev/assets/design-styles/trendy/css/blocks/button.scss
+++ b/.dev/assets/design-styles/trendy/css/blocks/button.scss
@@ -3,6 +3,7 @@
 .wp-block-button__link:not(.wp-block-coblocks-social__button) {
 	box-shadow: 0.4em 0.4em 0 0 rgba(0, 0, 0, 0.075);
 	overflow: hidden;
+	transition: width 200ms cubic-bezier(0.7, 0, 0.3, 1);
 
 	&::after {
 		content: "→";
@@ -11,7 +12,8 @@
 		overflow: hidden;
 		position: relative;
 		top: 1px;
-		transition: width 100ms cubic-bezier(0.7, 0, 0.3, 1) 100ms, opacity 200ms cubic-bezier(0.7, 0, 0.3, 1), margin 200ms cubic-bezier(0.7, 0, 0.3, 1) 100ms;
+		transition: max-width 200ms cubic-bezier(0.7, 0, 0.3, 1), opacity 200ms cubic-bezier(0.7, 0, 0.3, 1), margin 100ms cubic-bezier(0.7, 0, 0.3, 1) 100ms;
+		max-width: 0;
 		width: 0;
 	}
 
@@ -21,7 +23,8 @@
 		&::after {
 			margin-left: 10px;
 			opacity: 1;
-			width: 20px;
+			max-width: 300px;
+			width: auto;
 		}
 	}
 }

--- a/.dev/assets/design-styles/trendy/css/blocks/button.scss
+++ b/.dev/assets/design-styles/trendy/css/blocks/button.scss
@@ -3,7 +3,7 @@
 .wp-block-button__link:not(.wp-block-coblocks-social__button) {
 	box-shadow: 0.4em 0.4em 0 0 rgba(0, 0, 0, 0.075);
 	overflow: hidden;
-	transition: width 200ms cubic-bezier(0.7, 0, 0.3, 1);
+	transition: width 100ms cubic-bezier(0.7, 0, 0.3, 1);
 
 	&::after {
 		content: "→";
@@ -13,7 +13,7 @@
 		overflow: hidden;
 		position: relative;
 		top: 1px;
-		transition: max-width 200ms cubic-bezier(0.7, 0, 0.3, 1), opacity 200ms cubic-bezier(0.7, 0, 0.3, 1), margin 100ms cubic-bezier(0.7, 0, 0.3, 1) 100ms;
+		transition: max-width 100ms cubic-bezier(0.7, 0, 0.3, 1), opacity 100ms cubic-bezier(0.7, 0, 0.3, 1), margin 100ms cubic-bezier(0.7, 0, 0.3, 1) 100ms;
 		width: 0;
 	}
 

--- a/.dev/assets/design-styles/trendy/css/blocks/button.scss
+++ b/.dev/assets/design-styles/trendy/css/blocks/button.scss
@@ -21,7 +21,7 @@
 		&::after {
 			margin-left: 10px;
 			opacity: 1;
-			width: 10px;
+			width: auto;
 		}
 	}
 }

--- a/.dev/assets/design-styles/trendy/css/blocks/button.scss
+++ b/.dev/assets/design-styles/trendy/css/blocks/button.scss
@@ -21,7 +21,7 @@
 		&::after {
 			margin-left: 10px;
 			opacity: 1;
-			width: auto;
+			width: 20px;
 		}
 	}
 }

--- a/.dev/assets/design-styles/trendy/css/blocks/button.scss
+++ b/.dev/assets/design-styles/trendy/css/blocks/button.scss
@@ -8,12 +8,12 @@
 	&::after {
 		content: "→";
 		display: inline-block;
+		max-width: 0;
 		opacity: 0;
 		overflow: hidden;
 		position: relative;
 		top: 1px;
 		transition: max-width 200ms cubic-bezier(0.7, 0, 0.3, 1), opacity 200ms cubic-bezier(0.7, 0, 0.3, 1), margin 100ms cubic-bezier(0.7, 0, 0.3, 1) 100ms;
-		max-width: 0;
 		width: 0;
 	}
 
@@ -22,8 +22,8 @@
 
 		&::after {
 			margin-left: 10px;
-			opacity: 1;
 			max-width: 300px;
+			opacity: 1;
 			width: auto;
 		}
 	}

--- a/.dev/tests/cypress/integration/customizer/customizer.spec.js
+++ b/.dev/tests/cypress/integration/customizer/customizer.spec.js
@@ -83,9 +83,9 @@ describe( 'Test the customizer works as intended.', () => {
 		// Start at the bottom of the list
 		designStyles.reverse().forEach( designStyle => {
 			cy.get( '#accordion-section-colors' ).click();
-			cy.wait( 1500 );
 			cy.get( 'label[for="_customize-input-design_style_control-radio-' + designStyle.toLowerCase() + '"]' ).click( { force: true } );
 
+			cy.wait( 1500 );
 			// Wait for the submit button to be ready.
 			cy.get('.publish-settings', { timeout: 10000 }).should('be.visible');
 			saveCustomizerSettings();

--- a/.dev/tests/cypress/integration/customizer/customizer.spec.js
+++ b/.dev/tests/cypress/integration/customizer/customizer.spec.js
@@ -40,7 +40,7 @@ describe( 'Test the customizer works as intended.', () => {
 	beforeEach( () => {
 		cy.visit( Cypress.env( 'localTestURL' ) + '/wp-admin/customize.php' );
 		cy.get( 'body' ).should( 'have.class', 'wp-customizer' );
-		// cy.frameLoaded( '[name="customize-preview-0"]' );
+		cy.frameLoaded( '[name="customize-preview-0"]' );
 	} );
 
 	it( 'Test Site title, description and a custom logo', () => {

--- a/.dev/tests/cypress/integration/customizer/customizer.spec.js
+++ b/.dev/tests/cypress/integration/customizer/customizer.spec.js
@@ -40,7 +40,7 @@ describe( 'Test the customizer works as intended.', () => {
 	beforeEach( () => {
 		cy.visit( Cypress.env( 'localTestURL' ) + '/wp-admin/customize.php' );
 		cy.get( 'body' ).should( 'have.class', 'wp-customizer' );
-		cy.frameLoaded( '[name="customize-preview-0"]' );
+		// cy.frameLoaded( '[name="customize-preview-0"]' );
 	} );
 
 	it( 'Test Site title, description and a custom logo', () => {
@@ -85,6 +85,7 @@ describe( 'Test the customizer works as intended.', () => {
 			cy.get( '#accordion-section-colors' ).click();
 			cy.get( 'label[for="_customize-input-design_style_control-radio-' + designStyle.toLowerCase() + '"]' ).click( { force: true } );
 
+			cy.wait( 1500 );
 			// Wait for the submit button to be ready.
 			cy.get('.publish-settings', { timeout: 10000 }).should('be.visible');
 			saveCustomizerSettings();

--- a/.dev/tests/cypress/integration/customizer/customizer.spec.js
+++ b/.dev/tests/cypress/integration/customizer/customizer.spec.js
@@ -83,9 +83,9 @@ describe( 'Test the customizer works as intended.', () => {
 		// Start at the bottom of the list
 		designStyles.reverse().forEach( designStyle => {
 			cy.get( '#accordion-section-colors' ).click();
+			cy.wait( 1500 );
 			cy.get( 'label[for="_customize-input-design_style_control-radio-' + designStyle.toLowerCase() + '"]' ).click( { force: true } );
 
-			cy.wait( 1500 );
 			// Wait for the submit button to be ready.
 			cy.get('.publish-settings', { timeout: 10000 }).should('be.visible');
 			saveCustomizerSettings();

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -150,3 +150,11 @@ jobs:
 
       - name: Run tests
         run: yarn test:e2e:customizer -- --record
+        
+      - name: Upload failure video
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-fail.mp4
+          path: ./.dev/tests/cypress/videos/e2e-fail.mp4
+          retention-days: 1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -155,6 +155,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: e2e-fail.mp4
-          path: ./.dev/tests/cypress/videos/e2e-fail.mp4
+          name: customizer.spec.js.mp4
+          path: ./.dev/tests/cypress/videos/customizer/customizer.spec.js.mp4
           retention-days: 1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -156,5 +156,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: customizer.spec.js.mp4
-          path: ./.dev/tests/cypress/videos/customizer/customizer.spec.js.mp4
+          path: ./.dev/tests/cypress/videos/**/*.mp4
           retention-days: 1


### PR DESCRIPTION
As reported in slack, the Trendy design style arrow button width is incorrect and not showing the full arrow on button hover.

**Example:**
https://wpnux.godaddy.com/v3?template=sommer&language=en_US&style=trendy&country=US

- [x] Updated the Cypress Github workflow to upload all .mp4 files on a test failure.
- [x] Fixed the Cypress e2e customizer test race condition.