### PR TITLE
Update WooCommerce product colors when inside of 'has-secondary-background-color' block.

### DIFF
--- a/.dev/assets/shared/css/woocommerce/single-product.scss
+++ b/.dev/assets/shared/css/woocommerce/single-product.scss
@@ -161,6 +161,15 @@
 	color: var(--go-caption--color--text);
 }
 
+// Nested within a block with a secondary background color.
+// We should use alternate colors for text within a secondary background.
+.has-secondary-background-color .wc-block-grid .wc-block-grid__products {
+	.wc-block-grid__product-title,
+	.wc-block-grid__product-price.price .woocommerce-Price-amount {
+		color: var(--go--color--primary);
+	}
+}
+
 .woocommerce-Price-amount {
 	color: var(--go-heading--color--text);
 }


### PR DESCRIPTION
Added some styles here to set the text color for the product titles and product price if the WooCommerce blocks are inside of a background colored block with `has-secondary-background-color`. In the shared styles for WooCommerce blocks, we set the text color for both titles and prices to match the secondary color. 

In cases where they are already within a secondary color background, we default instead to the 'primary' color. 
**Before**
![image](https://github.com/godaddy-wordpress/go/assets/30462574/46269247-864d-4eb8-ad38-7b887bfc0603)


**After**
![Screenshot 2024-02-15 at 10 50 01 AM](https://github.com/godaddy-wordpress/go/assets/30462574/3809393a-8d94-4882-830e-e7640c39a69e)
