### PR TITLE
1.8.9 updates to readme and changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+= 1.8.9 / 2024-02-27 =
+### Updates
+- Update WooCommerce product colors when inside of 'has-secondary-background-color' block. [905](https://github.com/godaddy-wordpress/go/pull/905)
+
+= 1.8.8 / 2024-01-06 =
+### Updates
+- Fix style issue in Trendy design style where button arrow is cut off above a certain font size. [902](https://github.com/godaddy-wordpress/go/pull/902)
+- Replace deprecated `is_amp_endpoint` with `amp_is_request`. [904](https://github.com/godaddy-wordpress/go/pull/904)
+
 = 1.8.7 / 2023-11-06 =
 - Bump the tested up to version to 6.4. [#899](https://github.com/godaddy-wordpress/go/pull/899)
 

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,6 @@ List of bespoke icons:
 - Comments icon
 
 == Changelog ==
-= 1.8.8 / 2024-01-06 =
+= 1.8.9 / 2024-02-27 =
 ### Updates
-- Fix style issue in Trendy design style where button arrow is cut off above a certain font size. [902](https://github.com/godaddy-wordpress/go/pull/902)
-- Replace deprecated `is_amp_endpoint` with `amp_is_request`. [904](https://github.com/godaddy-wordpress/go/pull/904)
+- Update WooCommerce product colors when inside of 'has-secondary-background-color' block. [905](https://github.com/godaddy-wordpress/go/pull/905)


### PR DESCRIPTION
- Update WooCommerce product colors when inside of 'has-secondary-background-color' block. [905](https://github.com/godaddy-wordpress/go/pull/905)