### PR TITLE
Fix: [i18n] String in dist/js/admin/block-filters.js:1234 are not displayed translated

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -368,6 +368,8 @@ function block_editor_assets() {
 		)
 	);
 
+	wp_set_script_translations( 'go-block-filters', 'go' );
+
 }
 
 /**


### PR DESCRIPTION
Fix: [i18n] String in dist/js/admin/block-filters.js:1234 are not displayed translated

Before:

![Screenshot 2024-04-06 alle 14 03 04](https://github.com/godaddy-wordpress/go/assets/1197819/140a64fb-86a6-4df5-ae85-3a13096b247b)

After:

![Screenshot 2024-04-06 alle 14 01 48](https://github.com/godaddy-wordpress/go/assets/1197819/494a7918-916d-4ffc-87e6-94e1e675a502)
