### PR TITLE
Fix where register_meta is hooked

### DIFF
--- a/.dev/tests/php/test-title-meta.php
+++ b/.dev/tests/php/test-title-meta.php
@@ -61,6 +61,8 @@ class Test_Title_Meta extends WP_UnitTestCase {
 	 */
 	function test_hide_page_title_callback() {
 
+		do_action( 'rest_api_init' );
+
 		$post_title_visible = $this->factory->post->create(
 			[
 				'post_title' => 'Show Post title',

--- a/includes/title-meta.php
+++ b/includes/title-meta.php
@@ -20,40 +20,40 @@ function setup() {
 
 	add_filter( 'go_page_title_args', $n( 'hide_page_title' ) );
 
-	add_action( 'rest_api_init', $n( 'register_meta' ) );
+	add_action( 'rest_api_init', function() {
+		register_meta(
+			'post',
+			'hide_page_title',
+			array(
+				'sanitize_callback' => 'Go\Title_Meta\hide_page_title_callback',
+				'type'              => 'string',
+				'description'       => __( 'Hide Page Title.', 'go' ),
+				'show_in_rest'      => true,
+				'single'            => true,
+			)
+		);
+	} );
 
 }
 
-function register_meta() {
+/**
+ * Hide page title meta callback
+ *
+ * @param  string $status Hide page title status (eg: enable, disabled).
+ *
+ * @return string Whether or not the page title should be enabled or not.
+ */
+function hide_page_title_callback( $status ) {
 
-	register_meta(
-		'post',
-		'hide_page_title',
-		array(
-			/**
-			 * Hide page title meta callback
-			 *
-			 * @param  string $status Hide page title status (eg: enable, disabled).
-			 *
-			 * @return string Whether or not the page title should be enabled or not.
-			 */
-			'sanitize_callback' => function( $status ) {
-				$status = strtolower( trim( $status ) );
+	$status = strtolower( trim( $status ) );
 
-				if ( ! in_array( $status, array( 'enabled', 'disabled' ), true ) ) {
+	if ( ! in_array( $status, array( 'enabled', 'disabled' ), true ) ) {
 
-					$status = '';
+		$status = '';
 
-				}
+	}
 
-				return $status;
-			},
-			'type'              => 'string',
-			'description'       => __( 'Hide Page Title.', 'go' ),
-			'show_in_rest'      => true,
-			'single'            => true,
-		)
-	);
+	return $status;
 
 }
 

--- a/includes/title-meta.php
+++ b/includes/title-meta.php
@@ -20,38 +20,40 @@ function setup() {
 
 	add_filter( 'go_page_title_args', $n( 'hide_page_title' ) );
 
+	add_action( 'rest_api_init', $n( 'register_meta' ) );
+
+}
+
+function register_meta() {
+
 	register_meta(
 		'post',
 		'hide_page_title',
 		array(
-			'sanitize_callback' => $n( 'hide_page_title_callback' ),
+			/**
+			 * Hide page title meta callback
+			 *
+			 * @param  string $status Hide page title status (eg: enable, disabled).
+			 *
+			 * @return string Whether or not the page title should be enabled or not.
+			 */
+			'sanitize_callback' => function( $status ) {
+				$status = strtolower( trim( $status ) );
+
+				if ( ! in_array( $status, array( 'enabled', 'disabled' ), true ) ) {
+
+					$status = '';
+
+				}
+
+				return $status;
+			},
 			'type'              => 'string',
 			'description'       => __( 'Hide Page Title.', 'go' ),
 			'show_in_rest'      => true,
 			'single'            => true,
 		)
 	);
-
-}
-
-/**
- * Hide page title meta callback
- *
- * @param  string $status Hide page title status (eg: enable, disabled).
- *
- * @return string Whether or not the page title should be enabled or not.
- */
-function hide_page_title_callback( $status ) {
-
-	$status = strtolower( trim( $status ) );
-
-	if ( ! in_array( $status, array( 'enabled', 'disabled' ), true ) ) {
-
-		$status = '';
-
-	}
-
-	return $status;
 
 }
 

--- a/includes/title-meta.php
+++ b/includes/title-meta.php
@@ -21,7 +21,7 @@ function setup() {
 	add_filter( 'go_page_title_args', $n( 'hide_page_title' ) );
 
 	add_action(
-		'rest_api_init',
+		'rest_api_init', 
 		/**
 		 * Register the meta field for the REST API.
 		 */

--- a/includes/title-meta.php
+++ b/includes/title-meta.php
@@ -21,7 +21,7 @@ function setup() {
 	add_filter( 'go_page_title_args', $n( 'hide_page_title' ) );
 
 	add_action(
-		'rest_api_init', 
+		'rest_api_init',
 		/**
 		 * Register the meta field for the REST API.
 		 */

--- a/includes/title-meta.php
+++ b/includes/title-meta.php
@@ -22,6 +22,9 @@ function setup() {
 
 	add_action(
 		'rest_api_init',
+		/**
+		 * Register the meta field for the REST API.
+		 */
 		function() {
 			register_meta(
 				'post',

--- a/includes/title-meta.php
+++ b/includes/title-meta.php
@@ -20,19 +20,22 @@ function setup() {
 
 	add_filter( 'go_page_title_args', $n( 'hide_page_title' ) );
 
-	add_action( 'rest_api_init', function() {
-		register_meta(
-			'post',
-			'hide_page_title',
-			array(
-				'sanitize_callback' => 'Go\Title_Meta\hide_page_title_callback',
-				'type'              => 'string',
-				'description'       => __( 'Hide Page Title.', 'go' ),
-				'show_in_rest'      => true,
-				'single'            => true,
-			)
-		);
-	} );
+	add_action(
+		'rest_api_init',
+		function() {
+			register_meta(
+				'post',
+				'hide_page_title',
+				array(
+					'sanitize_callback' => 'Go\Title_Meta\hide_page_title_callback',
+					'type'              => 'string',
+					'description'       => __( 'Hide Page Title.', 'go' ),
+					'show_in_rest'      => true,
+					'single'            => true,
+				)
+			);
+		}
+	);
 
 }
 


### PR DESCRIPTION
This was causing an warning to be thrown when `WP_DEBUG` was enabled, due to translation functions being called too early. Bug introduced in WordPress 6.7.