### PR TITLE
Fix height attribute for spacer block

### DIFF
--- a/partials/layouts/contact.php
+++ b/partials/layouts/contact.php
@@ -36,7 +36,7 @@ function go_coblocks_contact_layouts( $layouts ) {
 			array(
 				'core/spacer',
 				array(
-					'height' => 30,
+					'height' => '30px',
 				),
 				array(),
 			),

--- a/partials/layouts/home.php
+++ b/partials/layouts/home.php
@@ -18,7 +18,7 @@ function go_coblocks_home_layouts( $layouts ) {
 			array(
 				'core/spacer',
 				array(
-					'height' => 60,
+					'height' => '60px',
 				),
 				array(),
 			),
@@ -38,7 +38,7 @@ function go_coblocks_home_layouts( $layouts ) {
 			array(
 				'core/spacer',
 				array(
-					'height' => 20,
+					'height' => '20px',
 				),
 				array(),
 			),
@@ -941,7 +941,7 @@ function go_coblocks_home_layouts( $layouts ) {
 			array(
 				'core/spacer',
 				array(
-					'height' => 30,
+					'height' => '30px',
 				),
 				array(),
 			),


### PR DESCRIPTION
The spacer block has an error when used with the Layout Selector component from CoBlocks with layouts hosted here in Go. Specifically some Home and a contact layout have spacer blocks with a numeric height number. This block actually expects to see a string value now like '20px' for example. 

Tested the spacer layouts in local development environment. 
**Before:**
<img width="768" height="332" alt="Screenshot 2025-08-12 at 12 11 21 PM" src="https://github.com/user-attachments/assets/41d6bd2b-6e8c-42b6-b4e5-68955288e39c" />


**After:**
<img width="596" height="451" alt="Screenshot 2025-08-12 at 12 09 43 PM" src="https://github.com/user-attachments/assets/01dd7ffa-b5d4-4a25-9947-b432ff81490a" />
