### PR TITLE
Fix WooCommerce Fatal Error

### DIFF
--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -352,8 +352,9 @@ function disable_cart() {
 
 	global $woocommerce;
 
-	if ( is_admin() || $always_show_cart || ( $woocommerce->cart && 0 < $woocommerce->cart->get_cart_contents_count() ) ) {
+	$cart = isset( $woocommerce->cart ) ? $woocommerce->cart : null;
 
+	if ( is_admin() || $always_show_cart || ( $cart && 0 < $cart->get_cart_contents_count() ) ) {
 		return;
 
 	}

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -340,13 +340,6 @@ function empty_cart_message() {
  */
 function disable_cart() {
 
-	// Skip for API requests.
-	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-
-		return;
-
-	}
-
 	/**
 	 * Filter whether to always show the cart icon.
 	 * Default: `false`

--- a/includes/woocommerce.php
+++ b/includes/woocommerce.php
@@ -340,6 +340,13 @@ function empty_cart_message() {
  */
 function disable_cart() {
 
+	// Skip for API requests.
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+
+		return;
+
+	}
+
 	/**
 	 * Filter whether to always show the cart icon.
 	 * Default: `false`
@@ -352,7 +359,7 @@ function disable_cart() {
 
 	global $woocommerce;
 
-	if ( is_admin() || $always_show_cart || 0 < $woocommerce->cart->get_cart_contents_count() ) {
+	if ( is_admin() || $always_show_cart || ( $woocommerce->cart && 0 < $woocommerce->cart->get_cart_contents_count() ) ) {
 
 		return;
 


### PR DESCRIPTION
This is a bit of an edge case, and a strange one, but one that I caught while testing out other things with the REST API.

When using the default permalinks, and you have an empty cart, the site will fatal error because `$woocommerce->cart` isn't available. This PR just adds a check to make sure it's available for use before we actually use it.

**Permalinks:** Plain
**URL:** /wp-json/wp/v2/posts/

<img width="968" height="256" alt="image" src="https://github.com/user-attachments/assets/26b1323f-3cb9-406e-99eb-e699d9941e3d" />
